### PR TITLE
feat: support custom success messages for Netlify backded contact forms

### DIFF
--- a/exampleSite/content/home/contact.md
+++ b/exampleSite/content/home/contact.md
@@ -16,5 +16,9 @@ autolink = true
 #   1: Netlify (requires that the site is hosted by Netlify)
 #   2: formspree.io
 email_form = 2
+
+# Form success message path for Netlify https://docs.netlify.com/forms/setup/#success-messages
+# The path must be relative to the site root, starting with a /
+success_message = ""
 +++
 

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -16,7 +16,11 @@
 
     {{ $post_action := "" }}
     {{ if eq $page.Params.email_form 1 }}
-      {{ $post_action = "netlify" }}
+      {{ if $page.Params.success_message }}
+        {{ $post_action = printf "netlify  action=\"%s\"" $page.Params.success_message }}
+      {{ else }}
+        {{ $post_action = "netlify" }}
+      {{end}}
     {{ else }}
       {{ if not $data.email }}
         {{ errorf "Please set an email address for the contact form using the `email` parameter in `params.toml`. Otherwise, set `email_form = 0` to disable the contact form." }}


### PR DESCRIPTION
### Purpose

Add support for custom success messages for Netlify backed contact forms.

### Documentation

The corresponding documentation pull request on https://github.com/sourcethemes/academic-www/pull/27.
