### PR TITLE
Enable basic slides (reveal.js) settings. Allow display of slide_number and disable the vertical centering of slides

### DIFF
--- a/archetypes/slides/index.md
+++ b/archetypes/slides/index.md
@@ -13,6 +13,10 @@ slides:
   # Choose a code highlighting style (if highlighting enabled in `params.toml`)
   #   Light style: github. Dark style: dracula (default).
   highlight_style: dracula
+  # Choose to display slide number. true/false (default).
+  slide_number: false
+  # Vertical centering of slides. true (default) / false
+  vert_center: true
 ---
 
 # Title

--- a/layouts/slides/baseof.html
+++ b/layouts/slides/baseof.html
@@ -42,8 +42,11 @@
 <body>
 
   {{ block "main" . }}{{ end }}
-
+   
   <script src="{{ $cdn_url_reveal }}/js/reveal.min.js"></script>
+
+  {{- $slide_number := $.Param "slides.slide_number" | default false -}}
+  {{- $vert_center := $.Param "slides.vert_center" | default true -}}
 
   <script>
     window.revealPlugins = { dependencies: [
@@ -62,7 +65,9 @@
       { src: '{{ "js/vendor/reveal.js/plugin/notes/notes.js" | relURL }}', async: true }
     ]};
 
-    let revealDefaults = { center: true, controls: true, history: true, progress: true, transition: 'slide', mouseWheel: true };
+	
+	
+    let revealDefaults = { center: {{ $vert_center }}, controls: true, history: true, progress: true, transition: 'slide', mouseWheel: true, slideNumber:  {{ $slide_number }} };
     let revealOptions = Object.assign({}, revealDefaults, revealPlugins);
     Reveal.initialize(revealOptions);
   </script>


### PR DESCRIPTION
### Purpose

For the slides based on reveal.js. Enable configuration to allow display of slide_number and disable the vertical centering of slides.
