### PR TITLE
Add new parameters docs_authors to show authors in the Docs layout

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -155,6 +155,7 @@ reading_time = true
 # Display next/previous section pager? (true/false)
 section_pager = false
 docs_section_pager = true  # Display pager in Docs layout (e.g. tutorials)?
+docs_authors = false # Display authors for Docs layout
 
 # Enable in-built social sharing buttons? (true/false)
 sharing = true

--- a/layouts/partials/docs_layout.html
+++ b/layouts/partials/docs_layout.html
@@ -28,7 +28,9 @@
           <div class="article-style">
             {{ .Content }}
           </div>
-
+          {{ if site.Params.docs_authors }}
+		     {{ partial "page_author" . }}
+		  {{ end }}
           {{ partial "tags.html" . }}
 
           {{ if site.Params.docs_section_pager }}


### PR DESCRIPTION
### Purpose

 `Fixes #1791 `  Add new parameters docs_authors to show authors in the Docs layout

### Screenshots

The author list will show the the bottom of Docs layout when parameter docs_authors set to true. 

![image](https://user-images.githubusercontent.com/1657381/88506463-4fd1cd00-d01d-11ea-81df-31f6a09ccfac.png)

### Documentation

`docs_authors` set as true to show the list of authors for Docs layout.