### PR TITLE
Update featurette.html

### DIFF
--- a/layouts/partials/widgets/featurette.html
+++ b/layouts/partials/widgets/featurette.html
@@ -21,6 +21,7 @@
   {{ if in (slice "fab" "fas" "far" "fal") $pack }}
     {{ $pack_prefix = "fa" }}
   {{ end }}
+  {{ with .url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
   <div class="col-12 col-sm-4">
     {{ with .icon }}
     <div class="featurette-icon">
@@ -34,6 +35,7 @@
       {{- end -}}
     </div>
     {{ end }}
+    {{ with .url }}</a>{{ end }}
     <h3>{{ .name | markdownify | emojify }}</h3>
     {{ with .description }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
   </div>


### PR DESCRIPTION
### Purpose

This PR is addresses the enhancements requested in #1797 and for the initial request in #1702 for clickable featurette icons that link to some URL provided in the associated markdown file. 

NOTE: I did not implement the `.featurette-icon` scaling suggested in the later issue although it could be handled by adding the following

`academic/assets/scss/academic/_widgets.scss`
``` 
.featurette-icon:hover {
  transform: scale(1.1);
}
```

### Screenshots

![clickable icon demo](https://user-images.githubusercontent.com/4616809/89091219-b4ae5f80-d35c-11ea-9de7-ce15777f9c08.gif)


### Documentation

The featurette documentation could be improved by letting people know that if you provide a URL, it will link to the destination. 

Change Location: https://sourcethemes.com/academic/docs/page-builder/#featurette

Possible alternative: 

```
widget = "featurette"
headless = true  # This file represents a page section.

# ... Put Your Section Options Here (title etc.) ...

# Showcase personal skills or business features.
# Add/remove as many `[[feature]]` blocks below as you like.
# For available icons, see: https://sourcethemes.com/academic/docs/widgets/#icons
[[feature]]
  icon = "r-project"
  icon_pack = "fab"
  name = "R"
  description = "90%"
  url = "https://www.r-project.org/" 
  
[[feature]]
  icon = "chart-line"
  icon_pack = "fas"
  name = "Statistics"
  description = "100%"  
  
[[feature]]
  icon = "camera-retro"
  icon_pack = "fas"
  name = "Photography"
  description = "10%"
  url = "https://www.your-favorite-photo-app.com/"

# Uncomment to use emoji icons.
# [[feature]]
#  icon = "😄"
#  icon_pack = "emoji"
#  name = "Emojiness"
#  description = "100%"  

# Uncomment to use custom SVG icons.
# Place custom SVG icon in `assets/images/icon-pack/`, creating folders if necessary.
# Reference the SVG icon name (without `.svg` extension) in the `icon` field.
# [[feature]]
#  icon = "your-custom-icon-name"
#  icon_pack = "custom"
#  name = "Surfing"
#  description = "90%"
```
