### PR TITLE
feat: add GIF to figure shortcode

### DIFF
--- a/wowchemy/layouts/shortcodes/figure.html
+++ b/wowchemy/layouts/shortcodes/figure.html
@@ -3,13 +3,17 @@
 {{ $media_dir := site.Params.media_dir | default "media" }}
 {{ $asset := (.Page.Resources.ByType "image").GetMatch (.Get "src") }}
 {{ $is_svg := false }}
+{{ $is_gif := false }}
 {{ if $asset }}
-  {{ if eq $asset.MediaType.SubType "svg"}}
+  {{ if eq $asset.MediaType.SubType "svg" }}
     {{ $is_svg = true }}
+  {{ end }}
+  {{ if eq $asset.MediaType.SubType "gif"}}
+    {{ $is_gif = true }}
   {{ end }}
 {{ end }}
 {{ $image_src := (.Get "src") }}
-{{ if and $asset (not $is_svg) }}
+{{ if and $asset (not $is_svg) (not $is_gif) }}
   {{ $asset2 := $asset.Fit "2000x2000" }}
   {{ $image_src = $asset2.RelPermalink }}
 {{ else if .Get "library" }}
@@ -34,7 +38,7 @@
 {{ end -}}
 
 {{/* Lazy load only when we know image dimensions in order to preserve anchor linking. */}}
-{{ if and $asset (not $is_svg) }}
+{{ if and $asset (not $is_svg) (not $is_gif)}}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" width="{{ (.Get "width") | default $asset.Width }}" height="{{ (.Get "height") | default $asset.Height }}">
 {{ else if and (.Get "width") (.Get "height") }}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" {{ with .Get "width" }}width="{{.}}"{{end}} {{ with .Get "height" }}height="{{.}}"{{end}}>


### PR DESCRIPTION
## Add GIF support for figure shortcode

### Features
Add `.gif` to figure shortcode

### Example:
[blog example](https://ckli.xyz/post/cmc/#what-is-contrastive-learning)