### PR TITLE
feat: make opening external links in a new tab configurable

### DIFF
--- a/wowchemy/layouts/_default/_markup/render-link.html
+++ b/wowchemy/layouts/_default/_markup/render-link.html
@@ -1,2 +1,2 @@
 {{- /* A Hugo Markdown render hook to parse links, opening external links in new tabs. */ -}}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" | and site.Params.new_tab_for_external }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/wowchemy/layouts/_default/list.html
+++ b/wowchemy/layouts/_default/list.html
@@ -1,4 +1,5 @@
 {{- define "main" -}}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 {{ partial "page_header.html" . }}
 
@@ -13,7 +14,7 @@
     {{ $target := "" }}
     {{ with .Params.external_link }}
       {{ $link = . }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ if $newTab }}{{ $target = "target=\"_blank\" rel=\"noopener\"" }}{{ end }}
     {{ end }}
     <div>
       <h2><a href="{{$link}}" {{ $target | safeHTMLAttr }}>{{ .Title }}</a></h2>

--- a/wowchemy/layouts/partials/li_compact.html
+++ b/wowchemy/layouts/partials/li_compact.html
@@ -1,4 +1,5 @@
 {{ $item := . }}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 {{/* Dynamic view adjusts to content type. */}}
 {{ $show_authors_only := false }}{{/* Show authors only or full metadata? */}}
@@ -34,7 +35,7 @@
   <div class="media-body">
 
     <h3 class="article-title mb-0 mt-0">
-      <a href="{{$link}}" {{ $target | safeHTMLAttr }}>{{ $item.Title }}</a>
+      <a href="{{$link}}"{{ if $newTab }} {{ $target | safeHTMLAttr }}{{ end }}>{{ $item.Title }}</a>
     </h3>
 
     {{ with $summary }}

--- a/wowchemy/layouts/partials/li_list.html
+++ b/wowchemy/layouts/partials/li_list.html
@@ -1,4 +1,5 @@
 {{ $item := . }}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 {{/* Dynamic view adjusts to content type. */}}
 {{ $icon_pack := "far" }}
@@ -27,7 +28,7 @@
 
 <div class="view-list-item">
   <i class="{{$icon_pack}} {{$icon}} pub-icon" aria-hidden="true"></i>
-  <a href="{{$link}}" {{ $target | safeHTMLAttr }}>{{ $item.Title }}</a>
+  <a href="{{$link}}"{{ if $newTab }} {{ $target | safeHTMLAttr }}{{ end }}>{{ $item.Title }}</a>
 
   {{ if eq $item.Type "talk" }}
   <div class="article-metadata">

--- a/wowchemy/layouts/partials/page_links.html
+++ b/wowchemy/layouts/partials/page_links.html
@@ -1,3 +1,4 @@
+{{ $newTab := site.Params.new_tab_for_external }}
 {{ $is_list := .is_list }}
 {{ $page := .page }}
 {{ $link := "" }}
@@ -10,7 +11,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_preprint" }}
 </a>
 {{ end }}
@@ -25,7 +26,7 @@
 {{ end }}
 
 {{ with $pdf }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ . }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_pdf" }}
 </a>
 {{ end }}
@@ -43,7 +44,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_code" }}
 </a>
 {{ end }}
@@ -54,7 +55,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_dataset" }}
 </a>
 {{ end }}
@@ -70,7 +71,7 @@
 {{ end }}
 {{ else }}
 {{ with $page.Params.url_project }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ . }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_project" }}
 </a>
 {{ end }}
@@ -82,7 +83,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_poster" }}
 </a>
 {{ end }}
@@ -100,7 +101,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_slides" }}
 </a>
 {{ end }}
@@ -112,7 +113,7 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_video" }}
 </a>
 {{ end }}
@@ -123,12 +124,12 @@
   {{ else }}
     {{ $link = . | relURL }}
   {{ end }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   {{ i18n "btn_source" }}
 </a>
 {{ end }}
 {{ with $page.Params.doi }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="https://doi.org/{{ . }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="https://doi.org/{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
   DOI
 </a>
 {{ end }}
@@ -148,7 +149,7 @@
     {{ else }}
       {{ $link = $link | relURL }}
     {{ end }}
-  {{ else if in (slice "http" "https") $scheme }}
+  {{ else if $newTab | and in (slice "http" "https") $scheme }}
     {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
   {{ end }}
   <a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/wowchemy/layouts/partials/page_links_div.html
+++ b/wowchemy/layouts/partials/page_links_div.html
@@ -1,6 +1,7 @@
 {{/* Div wrapper around page links. */}}
 {{/* The wrapper is hidden when the page has no link buttons. */}}
 
+{{ $newTab := site.Params.new_tab_for_external }}
 {{ $page := . }}
 {{ $pdf_link := false }}
 {{ $cite_link := false }}
@@ -18,7 +19,7 @@
 {{ if $cite_link | or $pdf_link | or .Params.external_link | or .Params.url_preprint | or .Params.url_pdf | or .Params.url_slides | or .Params.url_video | or .Params.url_source | or .Params.url_code | or .Params.url_dataset | or .Params.url_poster | or .Params.url_project | or .Params.doi | or .Params.links | or .Params.projects | or .Params.slides }}
 <div class="btn-links mb-3">
   {{ with .Params.external_link }}
-  <a class="btn btn-outline-primary my-1" href="{{ . }}" target="_blank" rel="noopener">{{ i18n "open_project_site" }}</a>
+  <a class="btn btn-outline-primary my-1" href="{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>{{ i18n "open_project_site" }}</a>
   {{ end }}
   {{ partial "page_links" (dict "page" $page "is_list" 0) }}
 </div>

--- a/wowchemy/layouts/partials/share.html
+++ b/wowchemy/layouts/partials/share.html
@@ -1,4 +1,5 @@
 {{ if and site.Params.sharing (ne .Params.share false) }}
+{{ $newTab := site.Params.new_tab_for_external }}
 <div class="share-box" aria-hidden="true">
   <ul class="share">
     {{ range where site.Data.page_sharer.buttons "enable" true }}
@@ -10,7 +11,7 @@
       {{ $link := replace .url "{url}" ($.Permalink | htmlEscape) }}
       {{ $link = replace $link "{title}" ($.Title | htmlEscape) }}
       <li>
-        <a href="{{$link|safeURL}}" target="_blank" rel="noopener" class="share-btn-{{.id}}">
+        <a href="{{$link|safeURL}}"{{ if $newTab }} target="_blank" rel="noopener"{{end}} class="share-btn-{{.id}}">
           <i class="{{$pack}} {{$pack_prefix}}-{{.icon}}"></i>
         </a>
       </li>

--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -1,3 +1,4 @@
+{{ $newTab := site.Params.new_tab_for_external }}
 <footer class="site-footer">
   {{ if or (site.GetPage "terms.md") (site.GetPage "privacy.md") }}
   <p class="powered-by">
@@ -23,8 +24,8 @@
     {{ $hide_published_with_footer := site.Params.power_ups.hide_published_with | default true }}
     {{ if not (and $is_sponsor $hide_published_with_footer) }}
     Published with
-    <a href="https://wowchemy.com" target="_blank" rel="noopener">Wowchemy</a>  —
-    the free, <a href="https://github.com/wowchemy/wowchemy-hugo-modules" target="_blank" rel="noopener">
+    <a href="https://wowchemy.com"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>Wowchemy</a>  —
+    the free, <a href="https://github.com/wowchemy/wowchemy-hugo-modules"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
     open source</a> website builder that empowers creators.
     {{ end }}
   </p>

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -4,6 +4,7 @@
 
 {{ if and $copyright_license $copyright_license.enable }}
 
+  {{ $newTab := site.Params.new_tab_for_external }}
   {{ $notice := .Params.copyright_license.notice | default site.Params.copyright_license.notice }}
   {{ $allow_commercial := .Params.copyright_license.allow_commercial | default site.Params.copyright_license.allow_commercial }}
   {{ $allow_derivatives := .Params.copyright_license.allow_derivatives | default site.Params.copyright_license.allow_derivatives }}
@@ -23,12 +24,18 @@
 
   {{ with $notice }}
   <p class="powered-by copyright-license-text">
-    {{ replace . "{license}" (printf "<a href=\"%s\" rel=\"noopener noreferrer\" target=\"_blank\">CC %s 4.0</a>" $license_url (replace $cc_code "-" " " | upper)) | markdownify }}
+    {{ $target := "" }}
+    {{ if $newTab }}
+      {{ $target := "rel=\"noopener noreferrer\" target=\"_blank\"" }}
+    {{ else }}
+      {{ $target := "rel=\"noreferrer\"" }}
+    {{ end }}
+    {{ replace . "{license}" (printf "<a href=\"%s\" %s>CC %s 4.0</a>" $license_url $target (replace $cc_code "-" " " | upper)) | markdownify }}
   </p>
   {{ end }}
 
   <p class="powered-by footer-license-icons">
-    <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank">
+    <a href="{{$license_url}}"{{ if $newTab }} rel="noopener noreferrer" target="_blank"{{ end }}>
       <img src="https://search.creativecommons.org/static/img/cc_icon.svg" alt="CC icon">
       <img src="https://search.creativecommons.org/static/img/cc-by_icon.svg" alt="CC by icon">
       {{ if not $allow_commercial }}

--- a/wowchemy/layouts/partials/social_links.html
+++ b/wowchemy/layouts/partials/social_links.html
@@ -1,3 +1,4 @@
+{{ $newTab := site.Params.new_tab_for_external }}
 <ul class="network-icon" aria-hidden="true">
   {{ range .Params.social }}
     {{ $pack := or .icon_pack "fas" }}
@@ -14,7 +15,7 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
-      <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
+      <a href="{{ $link | safeURL }}"{{ if $newTab }} {{ $target | safeHTMLAttr }}{{ end }}>
         <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"></i>
       </a>
     </li>

--- a/wowchemy/layouts/partials/widgets/about.html
+++ b/wowchemy/layouts/partials/widgets/about.html
@@ -1,4 +1,5 @@
 {{ $ := .root }}
+{{ $newTab := site.Params.new_tab_for_external }}
 {{ $page := .page }}
 
 {{ $author := "" }}
@@ -35,7 +36,7 @@
 
         {{ range $person.organizations }}
         <h3>
-          {{ with .url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+          {{ with .url }}<a href="{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>{{ end }}
           <span>{{ .name }}</span>
           {{ if .url }}</a>{{ end }}
         </h3>
@@ -54,7 +55,7 @@
         {{ $target := "" }}
         {{ if not $scheme }}
           {{ $link = .link | relLangURL }}
-        {{ else if in (slice "http" "https") $scheme }}
+        {{ else if $newTab | and in (slice "http" "https") $scheme }}
           {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
         {{ end }}
         <li>

--- a/wowchemy/layouts/partials/widgets/accomplishments.html
+++ b/wowchemy/layouts/partials/widgets/accomplishments.html
@@ -1,6 +1,7 @@
 {{ $ := .root }}
 {{ $page := .page }}
 {{ $columns := $page.Params.design.columns | default "2" }}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 <!-- Accomplishments widget -->
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
@@ -10,12 +11,12 @@
   {{ range $idx, $key := sort $page.Params.item ".date_start" "desc" }}
     <div class="card experience course">
       <div class="card-body">
-        {{- with .url -}}<a href="{{.}}" target="_blank" rel="noopener">{{- end -}}
+        {{- with .url -}}<a href="{{.}}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>{{- end -}}
         <h4 class="card-title exp-title text-muted my-0">{{.title | markdownify | emojify}}</h4>
         {{- with .url -}}</a>{{- end -}}
 
         <div class="card-subtitle my-0 article-metadata">
-          {{- with .organization_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end -}}
+          {{- with .organization_url}}<a href="{{.}}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>{{end -}}
           {{- .organization | markdownify | emojify -}}
           {{- with .organization_url}}</a>{{end -}}
 
@@ -32,7 +33,7 @@
         {{end}}
 
         {{ with .certificate_url }}
-          <a class="card-link" href="{{.}}" target="_blank" rel="noopener">
+          <a class="card-link" href="{{.}}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>
             {{ i18n "see_certificate" | default "See certificate" }}
           </a>
         {{ end }}

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -2,6 +2,7 @@
 {{ $st := .page }}
 {{ $autolink := default true $st.Params.autolink }}
 {{ $data := site.Params }}
+{{ $newTab := $data.new_tab_for_external }}
 
 {{ $columns := $st.Params.design.columns | default "2" }}
 

--- a/wowchemy/layouts/partials/widgets/experience.html
+++ b/wowchemy/layouts/partials/widgets/experience.html
@@ -1,4 +1,5 @@
 {{ $ := .root }}
+{{ $newTab := site.Params.new_tab_for_external }}
 {{ $page := .page }}
 {{ $columns := $page.Params.design.columns | default "2" }}
 
@@ -30,7 +31,7 @@
         <div class="card-body">
           <h4 class="card-title exp-title text-muted mt-0 mb-1">{{.title | markdownify | emojify}}</h4>
           <h4 class="card-title exp-company text-muted my-0">
-            {{- with .company_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end}}{{.company | markdownify | emojify}}{{with .company_url}}</a>{{end -}}
+            {{- with .company_url}}<a href="{{.}}"{{ if $newTab }} target="_blank" rel="noopener"{{end}}>{{end}}{{.company | markdownify | emojify}}{{with .company_url}}</a>{{end -}}
           </h4>
           <div class="text-muted exp-meta">
             {{ (time .date_start).Format ($page.Params.date_format | default "January 2006") }} –

--- a/wowchemy/layouts/partials/widgets/hero.html
+++ b/wowchemy/layouts/partials/widgets/hero.html
@@ -1,6 +1,7 @@
 {{ $ := .root }}
 {{ $page := .page }}
 {{ $bg := $page.Params.design.background }}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 {{ if $page.Params.hero_media }}
 <div class="row">
@@ -31,7 +32,7 @@
         {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
       {{ end }}
     <p class="cta-btns">
-      <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} class="btn {{if $bg.text_color_light}}btn-light{{else}}btn-primary{{end}} btn-lg">{{ if $page.Params.cta.icon }}<i class="{{ $pack }} {{ $pack_prefix }}-{{ $page.Params.cta.icon }} pr-1" aria-hidden="true"></i>{{end}}{{ $page.Params.cta.label | markdownify | emojify | safeHTML }}</a>
+      <a href="{{ $link | safeURL }}"{{ if $newTab }} {{ $target | safeHTMLAttr }}{{ end }} class="btn {{if $bg.text_color_light}}btn-light{{else}}btn-primary{{end}} btn-lg">{{ if $page.Params.cta.icon }}<i class="{{ $pack }} {{ $pack_prefix }}-{{ $page.Params.cta.icon }} pr-1" aria-hidden="true"></i>{{end}}{{ $page.Params.cta.label | markdownify | emojify | safeHTML }}</a>
 
       {{/* Alternative Call-to-action link */}}
       {{ if $page.Params.cta_alt.url }}
@@ -43,7 +44,7 @@
         {{ else if in (slice "http" "https") $scheme }}
           {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
         {{ end }}
-      <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} class="hero-cta-alt pl-4">{{ $page.Params.cta_alt.label | markdownify | emojify | safeHTML }} <i class="fas fa-angle-right"></i></a>
+      <a href="{{ $link | safeURL }}"{{ if $newTab }} {{ $target | safeHTMLAttr }}{{ end }} class="hero-cta-alt pl-4">{{ $page.Params.cta_alt.label | markdownify | emojify | safeHTML }} <i class="fas fa-angle-right"></i></a>
       {{ end }}
     </p>
     {{ end }}

--- a/wowchemy/layouts/partials/widgets/portfolio.html
+++ b/wowchemy/layouts/partials/widgets/portfolio.html
@@ -5,6 +5,7 @@
 {{ $st := .page }}
 {{ $items_type := $st.Params.content.page_type | default "project" }}
 {{ $columns := $st.Params.design.columns | default "2" }}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 {{ if ne $columns "1" }}
 {{/* Standard dual-column layout. */}}
@@ -73,7 +74,9 @@
         {{ $target := "" }}
         {{ if $item.Params.external_link }}
           {{ $link = $item.Params.external_link }}
-          {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+          {{ if $newTab }}
+            {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+          {{ end }}
         {{ end }}
 
         {{ if eq $st.Params.design.view 1 }}

--- a/wowchemy/layouts/talk/single.html
+++ b/wowchemy/layouts/talk/single.html
@@ -1,4 +1,5 @@
 {{- define "main" -}}
+{{ $newTab := site.Params.new_tab_for_external }}
 
 <div class="pub">
 
@@ -34,7 +35,7 @@
         <div class="row">
           <div class="col-12 col-md-3 pub-row-heading">{{ i18n "event" }}</div>
           <div class="col-12 col-md-9">
-            {{ with .Params.event_url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+            {{ with .Params.event_url }}<a href="{{ . }}"{{ if $newTab }} target="_blank" rel="noopener"{{ end }}>{{ end }}
             {{ .Params.event | markdownify }}
             {{ if .Params.event_url }}</a>{{ end }}
           </div>


### PR DESCRIPTION
### Purpose

Fixes #1755

### Documentation

The change is essentially self-documenting, requiring only the addition of
```
# Open external links in a new tab?
new_tab_for_external = false
```
to the starter template's [config/_default/params.toml](https://github.com/wowchemy/starter-academic/blob/master/config/_default/params.toml).