### PR TITLE
Update Mapbox API (following classic style deprecation)

### DIFF
--- a/wowchemy/assets/js/academic.js
+++ b/wowchemy/assets/js/academic.js
@@ -271,7 +271,7 @@
             tileSize: 512,
             maxZoom: 18,
             zoomOffset: -1,
-            id: 'mapbox/outdoors-v11',
+            id: 'mapbox/streets-v11',
             accessToken: api_key
           }).addTo(map);
         } else {

--- a/wowchemy/assets/js/academic.js
+++ b/wowchemy/assets/js/academic.js
@@ -266,10 +266,12 @@
       } else {
         let map = new L.map('map').setView([lat, lng], zoom);
         if (map_provider == 3 && api_key.length) {
-          L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+          L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
             attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+            tileSize: 512,
             maxZoom: 18,
-            id: 'mapbox.streets',
+            zoomOffset: -1,
+            id: 'mapbox/outdoors-v11',
             accessToken: api_key
           }).addTo(map);
         } else {


### PR DESCRIPTION
### Purpose

Since June 1, 2020, the Mapbox classic styles are deprecated and may be removed in the future.

This change updates the Leaflet code to use the currently supported Mapbox style API according to the official documentation at https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/

Here is the relevant excerpt from the Mapbox documentation:

> Which classic styles are being deprecated?
> 
> All Mapbox classic styles will be deprecated. The following is a list of the Mapbox-maintained classic styles that are not receiving data updates and cannot be requested by new applications after June 1, 2020:
> 
>     mapbox.streets
>     mapbox.light
>     mapbox.dark
>     mapbox.streets-satellite
>     mapbox.outdoors
>     mapbox.run-bike-hike
>     mapbox.streets-basic
>     mapbox.wheatpaste
>     mapbox.comic
>     mapbox.pencil
>     mapbox.pirates
>     mapbox.emerald
>     mapbox.high-contrast
> 
> Applications that make requests to these styles should be updated to reference a modern Mapbox style.

This pull request simply implements the Leaflet code changes as documented here: https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/#leaflet-implementations

### Screenshots

The map style is a bit different, but the exact same old style does not exists anymore in the new styles.

Deprecated style `mapbox.streets`:

![image](https://user-images.githubusercontent.com/1447163/94228692-1c81c080-ff30-11ea-8515-51c02244e2bc.png)

New style `mapbox/streets-v11`:

![image](https://user-images.githubusercontent.com/1447163/94229059-0a545200-ff31-11ea-8fc4-f18b7ddfbfd0.png)

### Documentation

I think a simple note in the release notes that the Mapbox maps have been updated to the current non-deprecated API would suffice.

### Considerations for future enhancement

The major advantage of using Mapbox is the ability to design a custom style. However it is not possible currently for the user to specify the style id to use from the parameter file. I think it would be quite easy to add this ability in a separate PR. Let me know if you think it would be agreeable to you, then I could look into it.