### PR TITLE
Avoid showing invisible text using `font-display: swap`

### DIFF
--- a/wowchemy/assets/scss/academic/_card.scss
+++ b/wowchemy/assets/scss/academic/_card.scss
@@ -104,6 +104,7 @@ a.summary-link {
   opacity: 0;
   transition: all 0.2s ease-out;
   font-family: 'Font Awesome 5 Free';
+  font-display: swap;
   font-weight: 900;
   content: '\f0c1';
   text-align: center;

--- a/wowchemy/assets/scss/academic/_root.scss
+++ b/wowchemy/assets/scss/academic/_root.scss
@@ -566,6 +566,7 @@ div.alert > div:first-child::before {
   font-size: 1.5rem;
   color: #209cee;
   font-family: 'Font Awesome 5 Free';
+  font-display: swap;
   font-weight: 900;
   content: '\f05a';
   width: 1.5rem;
@@ -574,6 +575,7 @@ div.alert > div:first-child::before {
 
 div.alert-warning > div:first-child::before {
   font-family: 'Font Awesome 5 Free';
+  font-display: swap;
   font-weight: 900;
   color: #ff3860;
   content: '\f071';

--- a/wowchemy/assets/scss/academic/_search.scss
+++ b/wowchemy/assets/scss/academic/_search.scss
@@ -78,6 +78,7 @@
 
 #search-box::before {
   font-family: 'Font Awesome 5 Free';
+  font-display: swap;
   font-weight: 900;
   content: "\f002";
   font-size: 1rem;


### PR DESCRIPTION
### Purpose

- Avoid showing invisible text
- Improve Google Lighthouse score:

![image](https://user-images.githubusercontent.com/6395915/94268402-1a593b00-ff0b-11ea-97c3-3a238f1d7cf3.png)


- Related to https://github.com/nnadeau/nicholasnadeau-me/issues/26
- See https://web.dev/font-display/#how-to-avoid-showing-invisible-text 