### PR TITLE
Author links not working in publications pages (Issue 1861)

### DIFF
--- a/wowchemy/layouts/partials/page_metadata_authors.html
+++ b/wowchemy/layouts/partials/page_metadata_authors.html
@@ -4,7 +4,7 @@
 {{ with .Param $taxonomy }}
   {{ $link_authors := site.Params.link_authors | default true }}
   {{ range $index, $name_raw := . }}
-    {{- $profile_page := site.GetPage (printf "/%s/%s" $taxonomy .) -}}
+    {{- $profile_page := site.GetPage (printf "/%s/%s" $taxonomy . | urlize) -}}
     {{- $name := $profile_page.Title | default $name_raw -}}
     {{- if gt $index 0 }}, {{ end -}}
     <span {{ if site.Params.highlight_superuser | and (eq $profile_page.Params.superuser true) }}class="font-weight-bold"{{end}}>


### PR DESCRIPTION
### Purpose

Fixes #1861 

There was a missing urlize in author metadata partial, which meant that an author name of "First Last"
was not being converted to "First-Last" before calling Site.GetPage

This lookup was failing, which then meant the author permalink was not being used

### Screenshots

The fixed version (note the blue link on hover over my name. This was missing before the urlize): 
<img width="551" alt="image" src="https://user-images.githubusercontent.com/2095942/94584796-06993600-0277-11eb-9e7a-842e0e685731.png">

