### PR TITLE
feat: add additional power_ups option for sponsors

### DIFF
--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -19,7 +19,9 @@
   {{ partial "site_footer_license" . }}
 
   <p class="powered-by">
-    {{ if not site.Params.i_am_a_sponsor }}
+    {{ $is_sponsor := site.Params.i_am_a_sponsor | default false }}
+    {{ $hide_published_with_footer := site.Params.power_ups.hide_published_with_footer | default false }}
+    {{ if not (and $is_sponsor $hide_published_with_footer) }}
     Published with
     <a href="https://wowchemy.com" target="_blank" rel="noopener">Wowchemy</a>  —
     the free, <a href="https://github.com/wowchemy/wowchemy-hugo-modules" target="_blank" rel="noopener">

--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -20,7 +20,7 @@
 
   <p class="powered-by">
     {{ $is_sponsor := site.Params.i_am_a_sponsor | default false }}
-    {{ $hide_published_with_footer := site.Params.power_ups.hide_published_with_footer | default false }}
+    {{ $hide_published_with_footer := site.Params.power_ups.hide_published_with | default true }}
     {{ if not (and $is_sponsor $hide_published_with_footer) }}
     Published with
     <a href="https://wowchemy.com" target="_blank" rel="noopener">Wowchemy</a>  —


### PR DESCRIPTION
### Purpose
Consistency. 

(i think) @gcushen introduced config controlled "power up"s in my PR here: https://github.com/wowchemy/wowchemy-hugo-modules/pull/1852

This PR just simply allows control of the power up to be handled in config and uses an identical control mechanism to the code @gcushen used in the previously mentioned PR.

### Screenshots

none

### Documentation

None -- I've only seen power ups documented in Patreon.