### PR TITLE
Update disqus.html

### DIFF
--- a/wowchemy/layouts/partials/comments/disqus.html
+++ b/wowchemy/layouts/partials/comments/disqus.html
@@ -1,7 +1,7 @@
 {{ if site.Params.comments.disqus.shortname }}
 <div id="disqus_thread"></div>
 <script>
-  let disqus_config = function () {
+  var disqus_config = function () {
     {{with .Params.disqus_identifier }}this.page.identifier = '{{ . }}';{{end}}
     {{with .Params.disqus_title }}this.page.title = '{{ . }}';{{end}}
     {{with .Params.disqus_url }}this.page.url = '{{ . | html  }}';{{end}}


### PR DESCRIPTION
Using 'let' keyword doesn't properly work for the disqus configuration variables. 
The original Hugo disqus template uses 'var' (https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/disqus.html),
and the Disqus documentation (https://help.disqus.com/en/articles/1717084-javascript-configuration-variables) also uses the 'var' keyword.