### PR TITLE
Stop Netlify CMS from showing up in Google search results

### DIFF
--- a/netlify-cms-academic/static/admin/index.html
+++ b/netlify-cms-academic/static/admin/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en-us">
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>Wowchemy Content Manager</title>


### PR DESCRIPTION
Currently, the admin page of my site shows up in Google search results. Adding the noindex tag stops Google from indexing the page.
Searching for certain queries can find a lot of other sites built with Academic that have their admin page indexed on Google.