### PR TITLE
Change theme color for mobile browers

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -56,8 +56,8 @@
 
   {{ $css := site.Data.assets.css }}
   {{ $js := site.Data.assets.js }}
-  {{ if ne ($scr.Get "primary") "#fff" }}
-  <meta name="theme-color" content="{{ $scr.Get "primary" }}">
+  {{ if ne ($scr.Get "menu_primary") "#fff" }}
+  <meta name="theme-color" content="{{ $scr.Get "menu_primary" }}">
   {{ end }}
 
   {{/* Config LaTeX math rendering. */}}


### PR DESCRIPTION
Use "menu_primary" instead of "primary"

### Purpose

On mobile browsers such as chrome, the background color does not match the banner (see screenshot).
I am using theme "1950s", where the menu bar is turquoise, but the browser menu bar is pink.
With this commit, the browser menu bar also becomes turquoise (which I personally think is better.).

### Screenshots

![Screenshot_20201021-171120](https://user-images.githubusercontent.com/5456139/96787965-a8b4c580-13c0-11eb-8c35-d1534a3b1b8d.png)
