### PR TITLE
Replaces chat link on contributing instructions

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to Academic
 
-For **help**, **support**, and **questions** please use our **[community chat](https://spectrum.chat/academic)**  🚑.
+For **help**, **support**, and **questions** please use our **[community chat](https://discord.gg/z8wNYzb)**  🚑.
 
 ---
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to Academic
+# Contributing to Wowchemy
 
 For **help**, **support**, and **questions** please use our **[community chat](https://discord.gg/z8wNYzb)**  🚑.
 


### PR DESCRIPTION
Replaces spectrum with discord, as I believe discord is the prefered chat over spectrum.
Also, updates theme's name.