### PR TITLE
Use Font Awesome for CC icons in page footer

### DIFF
--- a/wowchemy/assets/scss/wowchemy/_footer.scss
+++ b/wowchemy/assets/scss/wowchemy/_footer.scss
@@ -34,11 +34,10 @@ footer .powered-by {
   list-style: none;
   height: auto;
   width: auto;
-  font-size: 0;  // Hack to remove space characters between icons without using UL.
   text-decoration: none;
 }
 
-.footer-license-icons img {
+.footer-license-icons i {
  display: inline-flex;
   margin-right: 8px;
   height: 22px;

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -29,16 +29,18 @@
 
   <p class="powered-by footer-license-icons">
     <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank">
-      <i class="fab fa-creative-commons"></i>
-      <i class="fab fa-creative-commons-by"></i>
+      <span style="letter-spacing:.75ch;">
+      <i class="fab fa-creative-commons fa-2x"></i>
+      <i class="fab fa-creative-commons-by fa-2x"></i>
       {{ if not $allow_commercial }}
-        <i class="fab fa-creative-commons-nc"></i>
+        <i class="fab fa-creative-commons-nc fa-2x"></i>
       {{end}}
       {{ if and $allow_derivatives $share_alike }}
-        <i class="fab fa-creative-commons-sa"></i>
+        <i class="fab fa-creative-commons-sa fa-2x"></i>
       {{ else if not $allow_derivatives }}
-        <i class="fab fa-creative-commons-nd"></i>
+        <i class="fab fa-creative-commons-nd fa-2x"></i>
       {{end}}
+      </span>
     </a>
   </p>
 

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -28,16 +28,16 @@
   {{ end }}
 
   <p class="powered-by footer-license-icons">
-    <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank">
-      <i class="fab fa-creative-commons fa-2x"></i>
-      <i class="fab fa-creative-commons-by fa-2x"></i>
+    <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank" aria-label="Creative Commons">
+      <i class="fab fa-creative-commons fa-2x" aria-hidden="true"></i>
+      <i class="fab fa-creative-commons-by fa-2x" aria-hidden="true"></i>
       {{ if not $allow_commercial }}
-        <i class="fab fa-creative-commons-nc fa-2x"></i>
+        <i class="fab fa-creative-commons-nc fa-2x" aria-hidden="true"></i>
       {{end}}
       {{ if and $allow_derivatives $share_alike }}
-        <i class="fab fa-creative-commons-sa fa-2x"></i>
+        <i class="fab fa-creative-commons-sa fa-2x" aria-hidden="true"></i>
       {{ else if not $allow_derivatives }}
-        <i class="fab fa-creative-commons-nd fa-2x"></i>
+        <i class="fab fa-creative-commons-nd fa-2x" aria-hidden="true"></i>
       {{end}}
     </a>
   </p>

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -29,7 +29,6 @@
 
   <p class="powered-by footer-license-icons">
     <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank">
-      <span style="letter-spacing:.75ch;">
       <i class="fab fa-creative-commons fa-2x"></i>
       <i class="fab fa-creative-commons-by fa-2x"></i>
       {{ if not $allow_commercial }}
@@ -40,7 +39,6 @@
       {{ else if not $allow_derivatives }}
         <i class="fab fa-creative-commons-nd fa-2x"></i>
       {{end}}
-      </span>
     </a>
   </p>
 

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -29,15 +29,15 @@
 
   <p class="powered-by footer-license-icons">
     <a href="{{$license_url}}" rel="noopener noreferrer" target="_blank">
-      <img src="https://search.creativecommons.org/static/img/cc_icon.svg" alt="CC icon">
-      <img src="https://search.creativecommons.org/static/img/cc-by_icon.svg" alt="CC by icon">
+      <i class="fab fa-creative-commons"></i>
+      <i class="fab fa-creative-commons-by"></i>
       {{ if not $allow_commercial }}
-        <img src="https://search.creativecommons.org/static/img/cc-nc_icon.svg" alt="CC NC icon">
+        <i class="fab fa-creative-commons-nc"></i>
       {{end}}
       {{ if and $allow_derivatives $share_alike }}
-        <img src="https://search.creativecommons.org/static/img/cc-sa_icon.svg" alt="CC SA icon">
+        <i class="fab fa-creative-commons-sa"></i>
       {{ else if not $allow_derivatives }}
-        <img src="https://search.creativecommons.org/static/img/cc-nd_icon.svg" alt="CC ND icon">
+        <i class="fab fa-creative-commons-nd"></i>
       {{end}}
     </a>
   </p>


### PR DESCRIPTION
The current CC icons (when activated) in the page footer, e.g.
 - `<img src="https://search.creativecommons.org/static/img/cc_icon.svg" alt="CC icon">`
result in 404 errors.

[Creative Commons Site](https://creativecommons.org/about/downloads/) suggests something like
 - `<img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="CC icon">`

But it seems, we can get the CC icons from the fab icon pack, which
seems even better.

Fixes #1931