### PR TITLE
Add definition for $show_organizations

### DIFF
--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -5,6 +5,7 @@
 {{ $page := .page }}
 {{ $show_social := $page.Params.design.show_social | default false }}
 {{ $show_interests := $page.Params.design.show_interests | default true }}
+{{ $show_organizations := $page.Params.design.show_organizations | default true }}
 
 <div class="row justify-content-center people-widget">
   {{ with $page.Title }}

--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -5,7 +5,7 @@
 {{ $page := .page }}
 {{ $show_social := $page.Params.design.show_social | default false }}
 {{ $show_interests := $page.Params.design.show_interests | default true }}
-{{ $show_organizations := $page.Params.design.show_organizations | default true }}
+{{ $show_organizations := $page.Params.design.show_organizations | default false }}
 
 <div class="row justify-content-center people-widget">
   {{ with $page.Title }}
@@ -52,7 +52,7 @@
 
     <div class="portrait-title">
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Title }}{{if $link}}</a>{{end}}</h2>
-      {{ if and $show_organizations .Params.organizations }}{{range .Params.organizations }}<h3><em>{{ .name | markdownify | emojify }}</em></h3>{{ end }}{{ end }}
+      {{ if and $show_organizations .Params.organizations }}{{ range .Params.organizations }}<h3>{{ .name }}</h3>{{ end }}{{ end }}
       {{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
       {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}


### PR DESCRIPTION
### Purpose

Commit 97606bf added support for `show_organizations` in the people widget. The original author forgot to add the definition of this variable at top of the widget, leading to hugo not being able to build the site because the variable was not initialized.

This commit adds a definition for `show_organizations` at the top of the widget to fix the build error.

### Documentation

As described in commit 97606bf, you can set the value of `show_organizations` in the people widget's `design` section. See an example config at [this page](https://wowchemy.com/docs/page-builder/#people) and add `show_organizations: true` at the end of it.