### PR TITLE
Option to suppress users' roles in people widget

### DIFF
--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -6,6 +6,7 @@
 {{ $show_social := $page.Params.design.show_social | default false }}
 {{ $show_interests := $page.Params.design.show_interests | default true }}
 {{ $show_organizations := $page.Params.design.show_organizations | default false }}
+{{ $show_role := $page.Params.design.show_role | default true }}
 
 <div class="row justify-content-center people-widget">
   {{ with $page.Title }}
@@ -53,7 +54,7 @@
     <div class="portrait-title">
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Title }}{{if $link}}</a>{{end}}</h2>
       {{ if and $show_organizations .Params.organizations }}{{ range .Params.organizations }}<h3>{{ .name }}</h3>{{ end }}{{ end }}
-      {{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
+      {{ if $show_role }}{{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}{{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
       {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
     </div>

--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -54,7 +54,7 @@
     <div class="portrait-title">
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Title }}{{if $link}}</a>{{end}}</h2>
       {{ if and $show_organizations .Params.organizations }}{{ range .Params.organizations }}<h3>{{ .name }}</h3>{{ end }}{{ end }}
-      {{ if $show_role }}{{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}{{ end }}
+      {{ if and $show_role .Params.role }}<h3>{{ .Params.role | markdownify | emojify }}</h3>{{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
       {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
     </div>


### PR DESCRIPTION
Previously suggested this in https://github.com/wowchemy/wowchemy-hugo-modules/issues/1580.

A similar option has recently been implemented for `$show_organizations`. Seems reasonable to treat all of these as options that can be switched on and off.

### Purpose

Implements #1580
