### PR TITLE
Add option to show existing social links in navbar

### DIFF
--- a/wowchemy/layouts/partials/functions/get_social_link.html
+++ b/wowchemy/layouts/partials/functions/get_social_link.html
@@ -2,17 +2,27 @@
 
 {{ $scr := newScratch }}
 
+{{/* Get icon name. */}}
+{{ $scr.SetInMap "social_link" "icon" .icon }}
+
+{{/* Get icon pack (default to Font Awesome's Solid pack). */}}
 {{ $pack := or .icon_pack "fas" }}
 {{ $scr.SetInMap "social_link" "icon_pack" $pack }}
 
+{{/* Derive Font Awesome class name prefix. */}}
 {{ $pack_prefix := $pack }}
 {{ if in (slice "fab" "fas" "far" "fal") $pack }}
   {{ $pack_prefix = "fa" }}
 {{ end }}
 {{ $scr.SetInMap "social_link" "pack_prefix" $pack_prefix }}
 
+{{/* Get tooltip label (default to none). */}}
+{{ $scr.SetInMap "social_link" "tooltip" (.label | default "") }}
+
+{{/* Get screen reader label (default to icon name). */}}
 {{ $scr.SetInMap "social_link" "aria_label" (.label | default .icon) }}
 
+{{/* Get external link or relative internal link. */}}
 {{ $link := .link }}
 {{ $target := "" }}
 {{ $scheme := (urls.Parse $link).Scheme }}

--- a/wowchemy/layouts/partials/functions/get_social_link.html
+++ b/wowchemy/layouts/partials/functions/get_social_link.html
@@ -1,3 +1,5 @@
+{{/* Function to return a linked social icon as a map from an iteration of an author's `social` data. */}}
+
 {{ $scr := newScratch }}
 
 {{ $pack := or .icon_pack "fas" }}
@@ -8,6 +10,8 @@
   {{ $pack_prefix = "fa" }}
 {{ end }}
 {{ $scr.SetInMap "social_link" "pack_prefix" $pack_prefix }}
+
+{{ $scr.SetInMap "social_link" "aria_label" (.label | default .icon) }}
 
 {{ $link := .link }}
 {{ $target := "" }}

--- a/wowchemy/layouts/partials/functions/parse_social_link.html
+++ b/wowchemy/layouts/partials/functions/parse_social_link.html
@@ -1,13 +1,13 @@
 {{ $scr := newScratch }}
 
 {{ $pack := or .icon_pack "fas" }}
-{{ $scr.SetInMap "icon_def" "icon_pack" $pack }}
+{{ $scr.SetInMap "social_link" "icon_pack" $pack }}
 
 {{ $pack_prefix := $pack }}
 {{ if in (slice "fab" "fas" "far" "fal") $pack }}
   {{ $pack_prefix = "fa" }}
 {{ end }}
-{{ $scr.SetInMap "icon_def" "pack_prefix" $pack_prefix }}
+{{ $scr.SetInMap "social_link" "pack_prefix" $pack_prefix }}
 
 {{ $link := .link }}
 {{ $target := "" }}
@@ -17,7 +17,7 @@
 {{ else if in (slice "http" "https") $scheme }}
   {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
 {{ end }}
-{{ $scr.SetInMap "icon_def" "link" $link }}
-{{ $scr.SetInMap "icon_def" "target" $target }}
+{{ $scr.SetInMap "social_link" "link" $link }}
+{{ $scr.SetInMap "social_link" "target" $target }}
 
-{{ return $scr.Get "icon_def" }}
+{{ return $scr.Get "social_link" }}

--- a/wowchemy/layouts/partials/functions/parse_social_link.html
+++ b/wowchemy/layouts/partials/functions/parse_social_link.html
@@ -1,13 +1,13 @@
 {{ $scr := newScratch }}
 
 {{ $pack := or .icon_pack "fas" }}
-{{ $scr.SetInMap "icondict" "icon_pack" $pack }}
+{{ $scr.SetInMap "icon_def" "icon_pack" $pack }}
 
 {{ $pack_prefix := $pack }}
 {{ if in (slice "fab" "fas" "far" "fal") $pack }}
   {{ $pack_prefix = "fa" }}
 {{ end }}
-{{ $scr.SetInMap "icondict" "pack_prefix" $pack_prefix }}
+{{ $scr.SetInMap "icon_def" "pack_prefix" $pack_prefix }}
 
 {{ $link := .link }}
 {{ $target := "" }}
@@ -17,7 +17,7 @@
 {{ else if in (slice "http" "https") $scheme }}
   {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
 {{ end }}
-{{ $scr.SetInMap "icondict" "link" $link }}
-{{ $scr.SetInMap "icondict" "target" $target }}
+{{ $scr.SetInMap "icon_def" "link" $link }}
+{{ $scr.SetInMap "icon_def" "target" $target }}
 
-{{ return $scr.Get "icondict" }}
+{{ return $scr.Get "icon_def" }}

--- a/wowchemy/layouts/partials/functions/parse_social_link.html
+++ b/wowchemy/layouts/partials/functions/parse_social_link.html
@@ -1,0 +1,23 @@
+{{ $scr := newScratch }}
+
+{{ $pack := or .icon_pack "fas" }}
+{{ $scr.SetInMap "icondict" "icon_pack" $pack }}
+
+{{ $pack_prefix := $pack }}
+{{ if in (slice "fab" "fas" "far" "fal") $pack }}
+  {{ $pack_prefix = "fa" }}
+{{ end }}
+{{ $scr.SetInMap "icondict" "pack_prefix" $pack_prefix }}
+
+{{ $link := .link }}
+{{ $target := "" }}
+{{ $scheme := (urls.Parse $link).Scheme }}
+{{ if not $scheme }}
+  {{ $link = .link | relLangURL }}
+{{ else if in (slice "http" "https") $scheme }}
+  {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+{{ end }}
+{{ $scr.SetInMap "icondict" "link" $link }}
+{{ $scr.SetInMap "icondict" "target" $target }}
+
+{{ return $scr.Get "icondict" }}

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -143,29 +143,27 @@
            For now just look for a superuser. If more than one superuser
            is defined, run through all of them. */}}
 
-      {{ range where site.Pages "Section" "authors" }}
-        {{ if .Params.superuser }}
-          {{ range .Params.social }}
-            {{ if .display.navbar }}
-              {{ $pack := or .icon_pack "fas" }}
-              {{ $pack_prefix := $pack }}
-              {{ if in (slice "fab" "fas" "far" "fal") $pack }}
-                {{ $pack_prefix = "fa" }}
-              {{ end }}
-              {{ $link := .link }}
-              {{ $scheme := (urls.Parse $link).Scheme }}
-              {{ $target := "" }}
-              {{ if not $scheme }}
-                {{ $link = .link | relLangURL }}
-              {{ else if in (slice "http" "https") $scheme }}
-                {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
-              {{ end }}
-              <li  class="nav-item">
-                <a href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
-                  <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
-                </a>
-              </li>
+      {{ range where (where site.Pages "Section" "authors") ".Params.superuser" true }}
+        {{ range .Params.social }}
+          {{ if .display.navbar }}
+            {{ $pack := or .icon_pack "fas" }}
+            {{ $pack_prefix := $pack }}
+            {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+              {{ $pack_prefix = "fa" }}
             {{ end }}
+            {{ $link := .link }}
+            {{ $scheme := (urls.Parse $link).Scheme }}
+            {{ $target := "" }}
+            {{ if not $scheme }}
+              {{ $link = .link | relLangURL }}
+            {{ else if in (slice "http" "https") $scheme }}
+              {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+            {{ end }}
+            <li  class="nav-item">
+              <a href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
+                <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
+              </a>
+            </li>
           {{ end }}
         {{ end }}
       {{ end }}

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default "bottom" }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default "bottom" }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default "bottom" }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default "bottom" }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -139,6 +139,37 @@
     </div><!-- /.navbar-collapse -->
 
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
+      {{/* Look for social icons that should be displayed in the navbar.
+           For now just look for a superuser. If more than one superuser
+           is defined, run through all of them. */}}
+
+      {{ range where site.Pages "Section" "authors" }}
+        {{ if .Params.superuser }}
+          {{ range .Params.social }}
+            {{ if .display.navbar }}
+              {{ $pack := or .icon_pack "fas" }}
+              {{ $pack_prefix := $pack }}
+              {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+                {{ $pack_prefix = "fa" }}
+              {{ end }}
+              {{ $link := .link }}
+              {{ $scheme := (urls.Parse $link).Scheme }}
+              {{ $target := "" }}
+              {{ if not $scheme }}
+                {{ $link = .link | relLangURL }}
+              {{ else if in (slice "http" "https") $scheme }}
+                {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+              {{ end }}
+              <li  class="nav-item">
+                <a href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
+                  <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
+                </a>
+              </li>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+
       {{ $show_search := site.Params.main_menu.show_search | default true }}
       {{ if and site.Params.search.engine $show_search }}
       <li class="nav-item">

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -146,10 +146,10 @@
       {{ range where (where site.Pages "Section" "authors") ".Params.superuser" true }}
         {{ range .Params.social }}
           {{ if .display.navbar }}
-            {{ $icondict := partial "functions/parse_social_link" . }}
+            {{ $icon_def := partial "functions/parse_social_link" . }}
             <li  class="nav-item">
-              <a class="nav-link" href="{{ $icondict.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $icondict.target | safeHTMLAttr }} aria-label="{{ .icon }}">
-                <i class="{{ $icondict.icon_pack }} {{ $icondict.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
+              <a class="nav-link" href="{{ $icon_def.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $icon_def.target | safeHTMLAttr }} aria-label="{{ .icon }}">
+                <i class="{{ $icon_def.icon_pack }} {{ $icon_def.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
               </a>
             </li>
           {{ end }}

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -139,7 +139,6 @@
     </div><!-- /.navbar-collapse -->
 
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
-<<<<<<< HEAD
       {{/* Look for social icons that should be displayed in the navbar.
            For now just look for a superuser. If more than one superuser
            is defined, run through all of them. */}}
@@ -169,8 +168,6 @@
         {{ end }}
       {{ end }}
 
-=======
->>>>>>> parent of abcd01a (adding author social icons to navbar)
       {{ $show_search := site.Params.main_menu.show_search | default true }}
       {{ if and site.Params.search.engine $show_search }}
       <li class="nav-item">

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -105,7 +105,7 @@
         {{end}}
 
         <li class="nav-item">
-          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>
@@ -129,7 +129,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="{{ .Params.tooltip_placement | default bottom }}" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if .Params.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{ .Params.tooltip }}"{{ end }}{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
             {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
           </a>
         </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -145,8 +145,8 @@
         {{ range where .Params.social ".display.header" true }}
           {{ $social_link := partial "functions/get_social_link" . }}
           <li class="nav-item d-none d-lg-inline-flex">
-            <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }} {{ $social_link.target | safeHTMLAttr }} aria-label="{{ .aria_label }}">
-              <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ .icon }}" aria-hidden="true"></i>
+            <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ with $social_link.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{.}}"{{ end }} {{ $social_link.target | safeHTMLAttr }} aria-label="{{ $social_link.aria_label }}">
+              <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ $social_link.icon }}" aria-hidden="true"></i>
             </a>
           </li>
         {{ end }}

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -160,7 +160,7 @@
               {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
             {{ end }}
             <li  class="nav-item">
-              <a href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
+              <a class="nav-link" href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
                 <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
               </a>
             </li>

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -146,22 +146,10 @@
       {{ range where (where site.Pages "Section" "authors") ".Params.superuser" true }}
         {{ range .Params.social }}
           {{ if .display.navbar }}
-            {{ $pack := or .icon_pack "fas" }}
-            {{ $pack_prefix := $pack }}
-            {{ if in (slice "fab" "fas" "far" "fal") $pack }}
-              {{ $pack_prefix = "fa" }}
-            {{ end }}
-            {{ $link := .link }}
-            {{ $scheme := (urls.Parse $link).Scheme }}
-            {{ $target := "" }}
-            {{ if not $scheme }}
-              {{ $link = .link | relLangURL }}
-            {{ else if in (slice "http" "https") $scheme }}
-              {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
-            {{ end }}
+            {{ $icondict := partial "functions/parse_social_link" . }}
             <li  class="nav-item">
-              <a class="nav-link" href="{{ $link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
-                <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
+              <a class="nav-link" href="{{ $icondict.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $icondict.target | safeHTMLAttr }} aria-label="{{ .icon }}">
+                <i class="{{ $icondict.icon_pack }} {{ $icondict.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
               </a>
             </li>
           {{ end }}

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -139,20 +139,16 @@
     </div><!-- /.navbar-collapse -->
 
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
-      {{/* Look for social icons that should be displayed in the navbar.
-           For now just look for a superuser. If more than one superuser
-           is defined, run through all of them. */}}
 
-      {{ range where (where site.Pages "Section" "authors") ".Params.superuser" true }}
-        {{ range .Params.social }}
-          {{ if .display.navbar }}
-            {{ $social_link := partial "functions/parse_social_link" . }}
-            <li  class="nav-item">
-              <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $social_link.target | safeHTMLAttr }} aria-label="{{ .icon }}">
-                <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
-              </a>
-            </li>
-          {{ end }}
+      {{/* Display any social links that the superuser chose to display in the header. */}}
+      {{ range where (where (where site.Pages "Section" "authors") ".Params.superuser" true) ".Params.social" "!=" nil }}
+        {{ range where .Params.social ".display.header" true }}
+          {{ $social_link := partial "functions/get_social_link" . }}
+          <li class="nav-item d-none d-lg-inline-flex">
+            <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }} {{ $social_link.target | safeHTMLAttr }} aria-label="{{ .aria_label }}">
+              <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ .icon }}" aria-hidden="true"></i>
+            </a>
+          </li>
         {{ end }}
       {{ end }}
 

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -139,6 +139,7 @@
     </div><!-- /.navbar-collapse -->
 
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
+<<<<<<< HEAD
       {{/* Look for social icons that should be displayed in the navbar.
            For now just look for a superuser. If more than one superuser
            is defined, run through all of them. */}}
@@ -168,6 +169,8 @@
         {{ end }}
       {{ end }}
 
+=======
+>>>>>>> parent of abcd01a (adding author social icons to navbar)
       {{ $show_search := site.Params.main_menu.show_search | default true }}
       {{ if and site.Params.search.engine $show_search }}
       <li class="nav-item">

--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -146,10 +146,10 @@
       {{ range where (where site.Pages "Section" "authors") ".Params.superuser" true }}
         {{ range .Params.social }}
           {{ if .display.navbar }}
-            {{ $icon_def := partial "functions/parse_social_link" . }}
+            {{ $social_link := partial "functions/parse_social_link" . }}
             <li  class="nav-item">
-              <a class="nav-link" href="{{ $icon_def.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $icon_def.target | safeHTMLAttr }} aria-label="{{ .icon }}">
-                <i class="{{ $icon_def.icon_pack }} {{ $icon_def.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
+              <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ if .label }} data-toggle="tooltip" data-placement="bottom" title="{{ .label }}"{{ end }}{{ $social_link.target | safeHTMLAttr }} aria-label="{{ .icon }}">
+                <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ .icon }}"  aria-hidden="true"></i>
               </a>
             </li>
           {{ end }}


### PR DESCRIPTION
### Purpose

This PR makes it easy to add tooltips to menu (navbar) items.
By adding new parameters to `menu.toml`, tooltips can be easily added to any non-dropdown menu items.

Example:
```ini
[[main]]
  id = "someID"
  name = "someName"
  url = "some/URL/" # Link URL.
  weight = 10
  [main.params]
    tooltip = "tooltipName" # Add tooltip to menu item. Not supported for dropdown items.
    tooltip_placement = "bottom" # Tooltip placement. Pick bottom, left or right. Defaults to bottom.
```

This PR is only supported by Hugo v0.79 or newer.

### File changes/additions

**Changed files:**
wowchemy/layouts/partials/navbar.html
