### PR TITLE
Fix horizontal overflow

### DIFF
--- a/wowchemy/assets/scss/wowchemy/_root.scss
+++ b/wowchemy/assets/scss/wowchemy/_root.scss
@@ -55,7 +55,7 @@ body.no-navbar {
   min-height: calc(100vh - 70px);
   display: grid;
   grid-template-rows: auto 1fr auto;
-  grid-template-columns: 100vw;
+  grid-template-columns: 100%;
 }
 @include media-breakpoint-down(md) {
   .page-wrapper {

--- a/wowchemy/assets/scss/wowchemy/_root.scss
+++ b/wowchemy/assets/scss/wowchemy/_root.scss
@@ -31,7 +31,7 @@ body {
   padding-top: 0;
   counter-reset: captions;
 
-  // Prevent horizontal scrollbar in case of 100vw grid applied to page with vertical scrollbar.
+  // Prevent horizontal scrollbar in case a site admin adds fixed width content without applying `max-width: 100%`.
   overflow-x: hidden;
 
   // Offset body content by fixed navbar height.
@@ -55,7 +55,7 @@ body.no-navbar {
   min-height: calc(100vh - 70px);
   display: grid;
   grid-template-rows: auto 1fr auto;
-  grid-template-columns: 100%;
+  grid-template-columns: auto;
 }
 @include media-breakpoint-down(md) {
   .page-wrapper {


### PR DESCRIPTION
### Purpose

The vw units include the scrollbar as part of the viewport width, as explained here: [https://stackoverflow.com/questions/29551606/why-does-vw-include-the-scrollbar-as-part-of-the-viewport](https://stackoverflow.com/questions/29551606/why-does-vw-include-the-scrollbar-as-part-of-the-viewport). This means that when the scrollbar is shown, 100vw is slightly wider than the actual width. This is what caused #1976. 
While the issue was technically fixed in 58c7dd7, it only hid the horizontal scrollbar. As can be seen in the screenshot, elements still overflow horizontally by a small amount and get cut off.

![image](https://user-images.githubusercontent.com/31186542/101235325-8b1d9000-36d0-11eb-8af7-1a7e7fd06827.png)

