### PR TITLE
Fix CSS fingerprinting

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -151,7 +151,7 @@
   {{ $sass_template := resources.Get "scss/main.scss" }}
   {{ $style := $sass_template | resources.ExecuteAsTemplate "main_parsed.scss" . | toCSS $css_options }}
   {{ $style := slice $css_bundle_head $style | resources.Concat "css/wowchemy.css" }}
-  {{- if (eq (getenv "HUGO_ENV") "production") -}}
+  {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") -}}
     {{- $style = $style | minify | fingerprint "md5" -}}
   {{- end -}}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}">

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -145,13 +145,13 @@
   {{ $css_comment := printf "/*!* Wowchemy v%s (https://wowchemy.com/) */\n" site.Data.wowchemy.version }}
   {{ $css_bundle_head := $css_comment | resources.FromString "css/bundle-head.css" }}
   {{ $css_options := dict "targetPath" "css/wowchemy.css" }}
-  {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") -}}
+  {{- if eq hugo.Environment "production" -}}
     {{- $css_options = merge $css_options (dict "outputStyle" "compressed") -}}
   {{- end -}}
   {{ $sass_template := resources.Get "scss/main.scss" }}
   {{ $style := $sass_template | resources.ExecuteAsTemplate "main_parsed.scss" . | toCSS $css_options }}
   {{ $style := slice $css_bundle_head $style | resources.Concat "css/wowchemy.css" }}
-  {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") -}}
+  {{- if eq hugo.Environment "production" -}}
     {{- $style = $style | minify | fingerprint "md5" -}}
   {{- end -}}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}">


### PR DESCRIPTION
When running `hugo server -e production`, the CSS file wasn't getting fingerprinted. (Note that this issue doesn't affect Netlify deploys because Netlify automatically fingerprint it themselves).

Fixed by replacing the syntax of the if statement with the syntax used in line 148.