### PR TITLE
feat: reduce `apple-touch-icon` size

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -171,7 +171,7 @@
 
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   <link rel="icon" type="image/png" href="{{(partial "functions/get_icon" 32).RelPermalink}}">
-  <link rel="apple-touch-icon" type="image/png" href="{{(partial "functions/get_icon" 192).RelPermalink}}">
+  <link rel="apple-touch-icon" type="image/png" href="{{(partial "functions/get_icon" 180).RelPermalink}}">
 
   <link rel="canonical" href="{{ .Permalink }}">
 


### PR DESCRIPTION
Fix size of the `apple-touch-icon`, according to https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/#app-icon-sizes (should be 180x180 instead of 192x192).

Note that Android uses the 192x192 size defined in the [`index.webmanifest`](https://github.com/wowchemy/wowchemy-hugo-modules/blob/e47738df5972e217ca7cd333018f07732a55d4c6/wowchemy/layouts/index.webmanifest#L9).