### PR TITLE
fix: don't put the tag when WebAppManifest is not enabled

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -169,7 +169,7 @@
   <link rel="alternate" href="{{.RelPermalink}}" type="application/rss+xml" title="{{site.Title}}">
   {{ end }}
 
-  {{ if .Site.Home.OutputFormats.Get "WebAppManifest" }}
+  {{ if site.Home.OutputFormats.Get "WebAppManifest" }}
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   {{ end }}
 

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -169,7 +169,10 @@
   <link rel="alternate" href="{{.RelPermalink}}" type="application/rss+xml" title="{{site.Title}}">
   {{ end }}
 
+  {{ if .Site.Home.OutputFormats.Get "WebAppManifest" }}
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
+  {{ end }}
+
   <link rel="icon" type="image/png" href="{{(partial "functions/get_icon" 32).RelPermalink}}">
   <link rel="apple-touch-icon" type="image/png" href="{{(partial "functions/get_icon" 192).RelPermalink}}">
 

--- a/wowchemy/layouts/slides/baseof.html
+++ b/wowchemy/layouts/slides/baseof.html
@@ -12,9 +12,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
 
-  {{ if .Site.Home.OutputFormats.Get "WebAppManifest" }}
+  {{ if site.Home.OutputFormats.Get "WebAppManifest" }}
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   {{ end }}
+  
   <link rel="icon" type="image/png" href="{{(partial "functions/get_icon" 32).RelPermalink}}">
   <link rel="apple-touch-icon" type="image/png" href="{{(partial "functions/get_icon" 192).RelPermalink}}">
 

--- a/wowchemy/layouts/slides/baseof.html
+++ b/wowchemy/layouts/slides/baseof.html
@@ -12,7 +12,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
 
+  {{ if .Site.Home.OutputFormats.Get "WebAppManifest" }}
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
+  {{ end }}
   <link rel="icon" type="image/png" href="{{(partial "functions/get_icon" 32).RelPermalink}}">
   <link rel="apple-touch-icon" type="image/png" href="{{(partial "functions/get_icon" 192).RelPermalink}}">
 


### PR DESCRIPTION
### Purpose

Fixes: #2055

The default behavior is unchanged since the templates have the following
section in config/_default/config.toml.

```
[outputs]
  home = [ "HTML", "RSS", "JSON", "WebAppManifest" ]
  section = [ "HTML", "RSS" ]
```