### PR TITLE
Add missing translations for theme switching

### DIFF
--- a/wowchemy/i18n/de.yaml
+++ b/wowchemy/i18n/de.yaml
@@ -18,6 +18,14 @@
   translation: 'Abbildung %d:'
 - id: edit_page
   translation: Seite editieren
+- id: theme_selector
+  translation: Einstellungen anzeigen
+- id: theme_light
+  translation: Hell
+- id: theme_dark
+  translation: Dunkel
+- id: theme_auto
+  translation: Automatisch
 - id: btn_preprint
   translation: Vorabdruck
 - id: btn_pdf


### PR DESCRIPTION
### Purpose

During the build, I get warnings for missing German translations for theme switching. This should fix this.

### Screenshots / Log output

```
Start building sites … 
i18n|MISSING_TRANSLATION|de|theme_selector
i18n|MISSING_TRANSLATION|de|theme_light
i18n|MISSING_TRANSLATION|de|theme_dark
i18n|MISSING_TRANSLATION|de|theme_auto
```
