### PR TITLE
Added Israel address format

### DIFF
--- a/wowchemy/data/address_formats.toml
+++ b/wowchemy/data/address_formats.toml
@@ -5,3 +5,4 @@ de = {order = ['street', 'postcode', 'city'], delimiters = ['<br>', ' ', '']}
 fr-fr = {order = ['street', 'postcode', 'city'], delimiters = ['<br>', ' ', '']}
 zh = {order = ['postcode', 'region', 'city', 'street'], delimiters = [' ', ' ', ' ', '']}
 pt-br = {order = ['street', 'city', 'region', 'postcode', 'country'], delimiters = ['<br>', ', ', '<br>', '<br>']}
+il = {order = ['street', 'city', 'postcode', 'country'], delimiters = [', ', '&nbsp;', ' ', '']}


### PR DESCRIPTION
### Purpose

Display addresses in Israel correctly. None of the other formats defined in address_formats.toml are suitable.