### PR TITLE
Add Finnish address

### DIFF
--- a/wowchemy/data/address_formats.toml
+++ b/wowchemy/data/address_formats.toml
@@ -6,3 +6,4 @@ fr-fr = {order = ['street', 'postcode', 'city'], delimiters = ['<br>', ' ', '']}
 zh = {order = ['postcode', 'region', 'city', 'street'], delimiters = [' ', ' ', ' ', '']}
 pt-br = {order = ['street', 'city', 'region', 'postcode', 'country'], delimiters = ['<br>', ', ', '<br>', '<br>']}
 il = {order = ['street', 'city', 'postcode', 'country'], delimiters = [', ', '&nbsp;', ' ', '']}
+fi = {order = ['street', 'postcode', 'city', 'country'], delimiters = [', ', ' ', ', ']}


### PR DESCRIPTION
Adding Finnish address format into contact widget. Hasn't yet been added.

### Screenshots

![image](https://user-images.githubusercontent.com/63186670/106391033-fa271480-63f3-11eb-91fb-960e2d355008.png)


### Documentation

To use: go to `params.toml` in config folder.
Change `address_format = "en-us"` into `address_format = "fi"`