### PR TITLE
Fix gist CSS bug

### DIFF
--- a/wowchemy/assets/scss/wowchemy/_dark.scss
+++ b/wowchemy/assets/scss/wowchemy/_dark.scss
@@ -83,13 +83,14 @@ body.dark,
 /* Override Table Striped in GitHub Gist */
 .gist-data table > tbody > tr:nth-child(odd) > td,
 .gist-data table > tbody > tr:nth-child(odd) > th {
-    background-color: var(--color-bg-primary) !important;
+  background-color: var(--color-bg-primary);
+  border-top: none;
 }
 
 /* Override Table Hover in GitHub Gist */
 .gist-data table > tbody > tr:hover > td,
 .gist-data table > tbody > tr:hover > th {
-    background-color: transparent;
+  background-color: transparent;
 }
 
 .dark .portrait-title h2 {

--- a/wowchemy/assets/scss/wowchemy/_dark.scss
+++ b/wowchemy/assets/scss/wowchemy/_dark.scss
@@ -80,6 +80,18 @@ body.dark,
   background-color: rgb(60, 62, 74);
 }
 
+/* Override Table Striped in GitHub Gist */
+.gist-data table > tbody > tr:nth-child(odd) > td,
+.gist-data table > tbody > tr:nth-child(odd) > th {
+    background-color: var(--color-bg-primary) !important;
+}
+
+/* Override Table Hover in GitHub Gist */
+.gist-data table > tbody > tr:hover > td,
+.gist-data table > tbody > tr:hover > th {
+    background-color: transparent;
+}
+
 .dark .portrait-title h2 {
   color: #fff;
 }

--- a/wowchemy/assets/scss/wowchemy/_dark.scss
+++ b/wowchemy/assets/scss/wowchemy/_dark.scss
@@ -80,17 +80,14 @@ body.dark,
   background-color: rgb(60, 62, 74);
 }
 
-/* Override Table Striped in GitHub Gist */
-.gist-data table > tbody > tr:nth-child(odd) > td,
-.gist-data table > tbody > tr:nth-child(odd) > th {
-  background-color: var(--color-bg-primary);
-  border-top: none;
-}
-
-/* Override Table Hover in GitHub Gist */
-.gist-data table > tbody > tr:hover > td,
-.gist-data table > tbody > tr:hover > th {
-  background-color: transparent;
+/* Fix Table Styles in GitHub Gist */
+.gist-data table > tbody > tr > td,
+.gist-data table > tbody > tr > th,
+.gist-data table > tbody > tr > td:hover,
+.gist-data table > tbody > tr > th:hover {
+    background-color: var(--color-bg-primary) !important;
+    border-top: 0;
+    border-bottom: 0;
 }
 
 .dark .portrait-title h2 {


### PR DESCRIPTION
### Purpose

Fixed CSS bug where dark mode table formatting is applied to GitHub gists.  This fix applies the same selectors under the .gist-data class to enforce default gist styles.

### Screenshots

Previous (when dark mode activated)
<img width="766" alt="Screenshot 2021-02-13 at 15 34 04" src="https://user-images.githubusercontent.com/16925654/107859507-d1f6d700-6e31-11eb-92fd-e5efbfbc7480.png">

(Now)
<img width="738" alt="Screenshot 2021-02-13 at 19 54 18" src="https://user-images.githubusercontent.com/16925654/107860348-dc679f80-6e36-11eb-81fd-4f8ee8224734.png">

### Documentation

N/A
