### PR TITLE
fix: comment provider never found

### DIFF
--- a/wowchemy/layouts/partials/comments.html
+++ b/wowchemy/layouts/partials/comments.html
@@ -1,7 +1,7 @@
 {{ $provider := trim (site.Params.comments.provider | lower) " " }}
 
 {{ if $provider }}
-  {{ $provider_tpl := printf "partials/comments/%s" $provider }}
+  {{ $provider_tpl := printf "partials/comments/%s.html" $provider }}
   {{ $provider_exists := templates.Exists $provider_tpl }}
   {{ if not $provider_exists }}
     {{ errorf "The '%s' comment provider was not found." $provider }}


### PR DESCRIPTION
### Purpose

After updating to Wowchemy 5.0.0 comments are never loaded even though the `engine` configuration has been replaced with `provider` in `params.toml`. Server startup fails with:

```
The 'disqus' comment provider was not found.
```

There seems to be a regression after refactoring. The template is never appended with the `.html` postfix.