### PR TITLE
Show pages as common search queries by default

### DIFF
--- a/wowchemy/layouts/404.html
+++ b/wowchemy/layouts/404.html
@@ -23,10 +23,12 @@
   {{end}}
 
   {{ if $search_queries }}
-    <h2>{{ i18n "user_profile_latest" }}</h2>
-    <ul>
+    <h2>{{ i18n "search_common_queries" | default "Common searches" }}</h2>
+    <ul class="fa-ul">
       {{ range $search_queries }}
-        <li><a href="{{.link | relURL}}">{{.query | markdownify | emojify}}</a></li>
+        <li>
+          <a href="{{.link | relURL}}"><i class="fa-li fas fa-search" aria-hidden="true"></i><span class="pl-1">{{.query | markdownify | emojify}}</span></a>
+        </li>
       {{ end }}
     </ul>
   {{ else }}

--- a/wowchemy/layouts/404.html
+++ b/wowchemy/layouts/404.html
@@ -15,15 +15,31 @@
 
   <p>{{ i18n "404_recommendations" }}</p>
 
-  {{ $query := site.RegularPages }}
-  {{ $count := len $query }}
-  {{ if gt $count 0 }}
-  <h2>{{ i18n "user_profile_latest" }}</h2>
-  <ul>
-    {{ range first 10 $query }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+  {{ $search_queries := false }}
+  {{ if isset site.Data (printf "search_queries.%s" .Site.Language.Lang) }}
+    {{ $search_queries = index site.Data (printf "search_queries.%s" .Site.Language.Lang) }}
+  {{ else if isset site.Data "search_queries" }}
+    {{ $search_queries = site.Data.search_queries }}
+  {{end}}
+
+  {{ if $search_queries }}
+    <h2>{{ i18n "user_profile_latest" }}</h2>
+    <ul>
+      {{ range $search_queries }}
+        <li><a href="{{.link | relURL}}">{{.query | markdownify | emojify}}</a></li>
+      {{ end }}
+    </ul>
+  {{ else }}
+    {{ $query := site.RegularPages }}
+    {{ $count := len $query }}
+    {{ if gt $count 0 }}
+    <h2>{{ i18n "user_profile_latest" }}</h2>
+    <ul>
+      {{ range first 10 $query }}
+        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      {{ end }}
+    </ul>
     {{ end }}
-  </ul>
   {{ end }}
 
 </div>

--- a/wowchemy/layouts/partials/search.html
+++ b/wowchemy/layouts/partials/search.html
@@ -42,6 +42,21 @@
           {{ end }}
         </ul>
       </div>
+      {{ else if eq $search_provider "wowchemy" }}
+        {{ $query := site.RegularPages }}
+        {{ $count := len $query }}
+        {{ if gt $count 0 }}
+        <div id="search-common-queries" class="pt-3">
+          <div class="font-weight-bold pb-3">{{ i18n "search_common_queries" | default "Common searches" }}</div>
+          <ul class="fa-ul">
+            {{ range first 8 $query }}
+              <li class="pb-3">
+                <a href="{{ .RelPermalink }}"><i class="fa-li fas fa-search" aria-hidden="true"></i><span class="pl-1">{{ .Title }}</span></a>
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
       {{ end }}
 
     </section>


### PR DESCRIPTION
### Purpose

Show common search queries by default if `search_queries.yaml` is not defined. The shown queries are the same ones that appear in the 404 page. The query count is limited to 8 but could be changed. We could also add an option to enable or disable this behaviour in `params.toml`. Below you can see screenshots comparing the 404 and search pages.

### Screenshots

#### 404 page
![image](https://user-images.githubusercontent.com/48165265/108607844-2c101300-73c3-11eb-8fb5-2bf5bcf6df3a.png)

#### Search page
![image](https://user-images.githubusercontent.com/48165265/108607827-0a169080-73c3-11eb-85b4-6034b0b6b53d.png)
