### PR TITLE
Remove warning about font

### DIFF
--- a/wowchemy/data/fonts/rose.toml
+++ b/wowchemy/data/fonts/rose.toml
@@ -2,7 +2,7 @@
 name = "Rose"
 
 # Optional Google font URL
-google_fonts = "Cutive+Mono|Lora:400,700|Roboto:400,700"
+google_fonts = "family=Cutive+Mono&family=Lora:wght@400;700&family=Roboto:wght@400;700&display=swap"
 
 # Font families
 heading_font = "Lora"


### PR DESCRIPTION
### Purpose

Below warning was showing in the terminal. Fixed it
`WARN 2021/03/11 15:49:52 There is a new version of Google Fonts. Learn how to upgrade your font pack at https://wowchemy.com/docs/customization/#custom-font`

