### PR TITLE
add category and featured filters to portfolio widget

### DIFF
--- a/wowchemy/layouts/partials/widgets/portfolio.html
+++ b/wowchemy/layouts/partials/widgets/portfolio.html
@@ -59,10 +59,20 @@
       {{ $query = $query | intersect $archive_page.Pages }}
     {{ end }}
 
+    {{ if $st.Params.content.filters.exclude_featured }}
+      {{ $query = where $query "Params.featured" "!=" true }}
+    {{ end }}
+    {{ if $st.Params.content.filters.featured_only }}
+      {{ $query = where $query "Params.featured" "=" true }}
+    {{ end }}
+
     {{ range $idx, $item := $query }}
 
       {{ $link := $item.RelPermalink }}
       {{ $target := "" }}
+      {{ if $item.Params.internal_link }}
+        {{ $link = $item.Params.internal_link }}
+      {{ end }}
       {{ if $item.Params.external_link }}
         {{ $link = $item.Params.external_link }}
         {{ $target = "target=\"_blank\" rel=\"noopener\"" }}

--- a/wowchemy/layouts/partials/widgets/portfolio.html
+++ b/wowchemy/layouts/partials/widgets/portfolio.html
@@ -44,13 +44,19 @@
     {{ end }}
   {{ end }}
 
-  <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase{{end}}">
+  <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase mt-5{{end}}">
 
     {{ $query := "" }}
+    {{ $archive_page := site.GetPage "Section" $items_type }}
     {{ if $st.Params.content.filters.tags }}
       {{ $query = where site.Pages "Params.tags" "intersect" $st.Params.content.filters.tags }}
     {{ else }}
       {{ $query = where site.RegularPages "Type" $items_type }}
+    {{ end }}
+
+    {{ if $st.Params.content.filters.category }}
+      {{ $archive_page = site.GetPage (printf "categories/%s" (urlize $st.Params.content.filters.category)) }}
+      {{ $query = $query | intersect $archive_page.Pages }}
     {{ end }}
 
     {{ range $idx, $item := $query }}

--- a/wowchemy/layouts/partials/widgets/portfolio.html
+++ b/wowchemy/layouts/partials/widgets/portfolio.html
@@ -44,7 +44,7 @@
     {{ end }}
   {{ end }}
 
-  <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase mt-5{{end}}">
+  <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase{{end}}">
 
     {{ $query := "" }}
     {{ $archive_page := site.GetPage "Section" $items_type }}


### PR DESCRIPTION
### Purpose

i need to pre-select by `category`, or filter by `featured` and need internal links

### Documentation

we just add the category filter in the widget, like in the pages one:

```
content:
  # Page type to display. E.g. project.
  page_type: project
  filters:
    category: "course"
    exclude_featured: false
    featured_only: false
```

in the project metadata, we can now use the `internal_link` if we want to link an internal page (external_link opens in a _blank )

