### PR TITLE
Fix nonexistent navbar button aria-controls ID

### DIFF
--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -30,7 +30,7 @@
 
     {{ if site.Menus.main }}
     <button type="button" class="navbar-toggler" data-toggle="collapse"
-            data-target="#navbar-content" aria-controls="navbar" aria-expanded="false" aria-label="{{ i18n "toggle_navigation" }}">
+            data-target="#navbar-content" aria-controls="navbar-content" aria-expanded="false" aria-label="{{ i18n "toggle_navigation" }}">
     <span><i class="fas fa-bars"></i></span>
     </button>
     {{ end }}


### PR DESCRIPTION
(I'm very new to web development.)

### Purpose

An HTML validator found that the `aria-controls` attribute of the navbar toggle button doesn't point to an element in the document. It's set to `navbar`, while the navbar IDs are `navbar-main` and `navbar-content`. I changed it to `navbar-content`.


