### PR TITLE
Prevent empty p tag in site footer when there is no copyright

### DIFF
--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -22,9 +22,11 @@
   </p>
   {{ end }}
 
+  {{ with site.Copyright }}
   <p class="powered-by">
-    {{ with site.Copyright }}{{ replace . "{year}" now.Year | markdownify}}{{ end }}
+    {{ replace . "{year}" now.Year | markdownify }}
   </p>
+  {{ end }}
 
   {{/* Display copyright license. */}}
   {{ partial "site_footer_license" . }}


### PR DESCRIPTION
### Purpose

There is an empty `p` tag in the site footer when there is no site copyright string since the `with` block is inside of the `p` tag. I moved the `with` block out of the `p` tag so that the tag doesn't appear when there is no copyright.