### PR TITLE
Add Plausible Analytics as a site analytics option

### DIFF
--- a/wowchemy/layouts/partials/marketing/plausible.html
+++ b/wowchemy/layouts/partials/marketing/plausible.html
@@ -1,6 +1,6 @@
 {{ $plausible_dd := site.Params.marketing.plausible_data_domain  | default "" }}
-{{ $plausible_js := site.Params.marketing.plausible_script | default "" }}
+{{ $plausible_js := site.Params.marketing.plausible_script | default "https://plausible.io/js/plausible.js" }}
 
-{{ if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and $plausible_dd | and $plausible_js }}
+{{ if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and $plausible_dd }}
 <script async defer data-domain="{{$plausible_dd}}" src="{{$plausible_js}}"></script>
 {{ end }}

--- a/wowchemy/layouts/partials/marketing/plausible.html
+++ b/wowchemy/layouts/partials/marketing/plausible.html
@@ -1,0 +1,6 @@
+{{ $plausible_dd := site.Params.marketing.plausible_data_domain  | default "" }}
+{{ $plausible_js := site.Params.marketing.plausible_script | default "" }}
+
+{{ if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and $plausible_dd | and $plausible_js }}
+<script async defer data-domain="{{$plausible_dd}}" src="{{$plausible_js}}"></script>
+{{ end }}

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -183,6 +183,7 @@
   {{ partial "marketing/google_tag_manager" . }}
   {{ partial "marketing/microsoft_clarity" . }}
   {{ partial "marketing/baidu_tongji" . }}
+  {{ partial "marketing/plausible" . }}
 
   {{/* Netlify Identity integration. */}}
   {{ $use_cms := templates.Exists "wowchemycms/single.wowchemycms_config.yml" | default (site.Params.cms.netlify_cms | default false) }}


### PR DESCRIPTION
### Purpose
[Plausible analytics](https://plausible.io) is a lightweight analytics system that respects user privacy by not using onerous tracking cookies. It has other advantages, such as being self-hostable for maximum privacy while retaining helpful site analytics.

This pull request adds Plausible as a separate analytics source for the Wowchemy set of sites. There are two configuration options that must be set in order, due to the ability to self-host Plausible analytics, the *data domain* (e.g. which endpoint you want your data to be accumulated at) and the *script URL*, which is often `https://plausible.io/js/plausible.js`, but can be at a different location if someone is self-hosting.

### Testing
I have not tested this change end-to-end (e.g. making a local Hugo module and importing it into a site). However, I have made identical changes in my own Wowchemy-defined site with an overriding `layouts/partials`; see relevant commits [here](https://github.com/meson800/meson800.github.io/commit/700be4126d9a65cfe8cb14b578f6e2b9bfe402f7) and [here](https://github.com/meson800/meson800.github.io/commit/12e8cd9d53e55dfffdac0087a6caabf8e868a617).

### Documentation

I'm unable to find the documentation repo or an edit link on https://wowchemy.com/docs/guide/analytics/ :(
I even searched all of Github for sentences pulled from that page; where is the relevant link?

In any case, this is the documentation that should be added:

---

## Plausible
After adding your site, Plausible will tell you to add a snippet of the following form:

```
<script async defer data-domain="example.com" src="https://plausible.io/js/plausible.js"></script>
```

Add the data domain to `config/_default/params.yaml`:

```
[marketing]
  plausible_data_domain = "example.com"
```

If you are self-hosting Plausible, such that the analytics script source is not `https://plausible.io/js/plausible.js`, add the `plausible_script` key, pointing at your custom location:

```
[marketing]
  plausible_data_domain = "example.com"
  plausible_script = "https://example.com/js/plausible.js"
```