### PR TITLE
Workaround Hugo bug with GetPages fetching page from a different path to that specified

### DIFF
--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -10,13 +10,13 @@
     </div>
   {{ end }}
 
-  {{ if or (site.GetPage "terms.md") (site.GetPage "privacy.md") }}
+  {{ if or (.GetPage "/terms.md") (.GetPage "/privacy.md") }}
   <p class="powered-by">
-    {{ with site.GetPage "privacy.md" }}
+    {{ with .GetPage "/privacy.md" }}
       {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
     {{ end }}
-    {{ with site.GetPage "terms.md" }}
-      {{ if site.GetPage "privacy.md" }} &middot; {{ end }}
+    {{ with .GetPage "/terms.md" }}
+      {{ if .GetPage "/privacy.md" }} &middot; {{ end }}
       {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
     {{ end }}
   </p>

--- a/wowchemy/layouts/partials/site_footer.html
+++ b/wowchemy/layouts/partials/site_footer.html
@@ -10,13 +10,13 @@
     </div>
   {{ end }}
 
-  {{ if or (.GetPage "/terms.md") (.GetPage "/privacy.md") }}
+  {{ if or (site.GetPage "/terms.md") (site.GetPage "/privacy.md") }}
   <p class="powered-by">
-    {{ with .GetPage "/privacy.md" }}
+    {{ with site.GetPage "/privacy.md" }}
       {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
     {{ end }}
-    {{ with .GetPage "/terms.md" }}
-      {{ if .GetPage "/privacy.md" }} &middot; {{ end }}
+    {{ with site.GetPage "/terms.md" }}
+      {{ if site.GetPage "/privacy.md" }} &middot; {{ end }}
       {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
     {{ end }}
   </p>


### PR DESCRIPTION
### Purpose

Fixes 2282, where Privacy link is shown when a tag name "Privacy" exists, even if "Privacy.md" is deleted. 

