### PR TITLE
feat: support Params.marketing.bing_site_verification

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -19,7 +19,7 @@
     <meta name="baidu-site-verification" content="{{ . }}" />
   {{- end -}}
   {{ with site.Params.marketing.bing_site_verification }}
-  <meta name="msvalidate.01" content="{{ . }}" />
+    <meta name="msvalidate.01" content="{{ . }}" />
   {{- end -}}
 
   {{ $scr := .Scratch }}

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -18,6 +18,9 @@
   {{ with site.Params.marketing.baidu_site_verification }}
     <meta name="baidu-site-verification" content="{{ . }}" />
   {{- end -}}
+  {{ with site.Params.marketing.bing_site_verification }}
+  <meta name="msvalidate.01" content="{{ . }}" />
+  {{- end -}}
 
   {{ $scr := .Scratch }}
 


### PR DESCRIPTION
Bing also supports site verification via HTML meta tags

### Purpose

Bing also supports site verification for SEO optimization and the site ranking is also used for other search providers such as DuckDuckGo.

### Documentation

Analog to the google or baidu site verification one can then also add this to `params.toml`: 

```
[marketing]
  bing_site_verification = "BING_TOKEN"
```
