### PR TITLE
feat: also allow other sites to enable fancy box loading

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -87,7 +87,7 @@
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.fontAwesome.url $css.fontAwesome.version) $css.fontAwesome.sri | safeHTML }}
 
     {{/* Workaround `.HasShortcode "gallery"` detection issue on `home/` WidgetPage v1 */}}
-    {{ if .HasShortcode "gallery" | or (and .IsHome (site.Params.require_fancybox | default true)) }}
+    {{ if .HasShortcode "gallery" | or (and .IsHome (site.Params.require_fancybox | default true)) | or site.Params.require_fancybox }}
       {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\" media=\"print\" onload=\"this.media='all'\">" (printf $css.fancybox.url $css.fancybox.version) $css.fancybox.sri | safeHTML }}
     {{ end }}
 

--- a/wowchemy/layouts/partials/site_js.html
+++ b/wowchemy/layouts/partials/site_js.html
@@ -15,7 +15,7 @@
       {{ end }}
 
       {{/* Workaround `.HasShortcode "gallery"` detection issue on `home/` WidgetPage v1 */}}
-      {{ if .HasShortcode "gallery" | or (and .IsHome (site.Params.require_fancybox | default true)) }}
+      {{ if .HasShortcode "gallery" | or (and .IsHome (site.Params.require_fancybox | default true)) | or site.Params.require_fancybox }}
         {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.fancybox.url $js.fancybox.version) $js.fancybox.sri | safeHTML }}
       {{ end }}
 


### PR DESCRIPTION
If a custom/altered gallery implementations use FancyBox one has to load FancyBox in a custom header. Add a site override to not introduce duplication.

### Purpose

In [https://github.com/wowchemy/wowchemy-hugo-modules/commit/dc09534e2b3744e1d290c5e09ce7979ecfad90f9](https://github.com/wowchemy/wowchemy-hugo-modules/commit/dc09534e2b3744e1d290c5e09ce7979ecfad90f9) and [https://github.com/wowchemy/wowchemy-hugo-modules/commit/7b235ea453b25345dbdaffc98d9c46a14ca5591b](https://github.com/wowchemy/wowchemy-hugo-modules/commit/7b235ea453b25345dbdaffc98d9c46a14ca5591b) FancyBox switched from being always loaded to only being loaded on the home page or when the gallery shortcut is used. However, if a user build a custom layout or alternate the gallery slightly one has to include it in `custom_head.html` and `custom_js.html`. This may introduce a version drift and double downloads of the same dependency. Add an override option similar to `math` which enables FancyBox loading for a specific site.

### Documentation

Similiar to `math: true` a user can now enable FancyBox on a specific site using the front matter:

`require_fancybox: true`
