### PR TITLE
Fix unminified JavaScript

### DIFF
--- a/wowchemy/layouts/partials/site_js.html
+++ b/wowchemy/layouts/partials/site_js.html
@@ -137,15 +137,15 @@
     {{ range site.Params.plugins_js }}
       {{ $js_bundle = $js_bundle | append (resources.Get (printf "js/%s.js" .)) }}
     {{ end }}
-    {{ $js_bundle := $js_bundle | resources.Concat (printf "%s/js/wowchemy-bundle.js" .Lang) }}
+    {{ $js_bundle = $js_bundle | resources.Concat (printf "%s/js/wowchemy-bundle.js" .Lang) }}
     {{- if hugo.IsProduction -}}
-      {{ $js_bundle = $js_bundle | minify }}
-    {{- end -}}
-    {{ $js_bundle := slice $js_bundle_head $js_bundle | resources.Concat (printf "%s/js/wowchemy.min.js" .Lang) }}
-    {{- if hugo.IsProduction -}}
-      {{- $js_bundle = $js_bundle | js.Build (dict "format" "iife") | fingerprint "md5" -}}
+      {{- $js_bundle = $js_bundle | js.Build (dict "format" "iife") | minify -}}
     {{- else -}}
       {{- $js_bundle = $js_bundle | js.Build (dict "format" "iife" "sourceMap" "inline") -}}
+    {{- end -}}
+    {{ $js_bundle = slice $js_bundle_head $js_bundle | resources.Concat (printf "%s/js/wowchemy.min.js" .Lang) }}
+    {{- if hugo.IsProduction -}}
+      {{ $js_bundle = $js_bundle | fingerprint "md5" }}
     {{- end -}}
     <script src="{{ $js_bundle.RelPermalink }}"></script>
 


### PR DESCRIPTION
Currently, the JS bundle first gets minified, has the copyright notice prepended, then passes through `js.Build`. The problem is that `js.Build` seems to pretty-print the code, so the result is not minified. I changed the order so that the bundle goes through `js.Build`, gets minified, and then has the copyright notice added.

This is what the final JS file looks like previously:
```js
(() => {
  // <stdin>
  /*! Wowchemy v5.1.0 | https://wowchemy.com/ */
  /*! Copyright 2016-present George Cushen (https://georgecushen.com/) */
  /*! License: https://github.com/wowchemy/wowchemy-hugo-modules/blob/main/LICENSE.md */
  (() => {
    var a = Object.assign || function(d2) {
      for (var a2 = 1, b2, c2; a2 < arguments.length; a2++) {
        b2 = arguments[a2];
        for (c2 in b2)
          Object.prototype.hasOwnProperty.call(b2, c2) && (d2[c2] = b2[c2]);
      }
      return d2;
    }, e = function(a2) {
      return a2.tagName === "IMG";
    }, V = function(a2) {
      return NodeList.prototype.isPrototypeOf(a2);
    }, f = function(a2) {
      return a2 && a2.nodeType === 1;
    }, B = function(a2) {
      var b2 = a2.currentSrc || a2.src;
      return b2.substr(-4).toLowerCase() === ".svg";
    }, A = function(a2) {
//...
```

And this is what it looks like after the change:
```js
/*! Wowchemy v5.1.0 | https://wowchemy.com/ */
/*! Copyright 2016-present George Cushen (https://georgecushen.com/) */
/*! License: https://github.com/wowchemy/wowchemy-hugo-modules/blob/main/LICENSE.md */

;
(()=>{(()=>{var a=Object.assign||function(d){for(var a=1,b,c;a<arguments.length;a++){b=arguments[a];for(c in b)Object.prototype.hasOwnProperty.call(b,c)&&(d[c]=b[c])}return d},e=function(a)
//...
```

It's also possible to have `js.Build` output minified code using `minify` option. If we add the license notice before minifying using `js.Build`, it will move the notice to the end.