### PR TITLE
Fix editorial_workflow mode for Netlify-CMS

### DIFF
--- a/wowchemy-cms/functions/parse.html
+++ b/wowchemy-cms/functions/parse.html
@@ -7,7 +7,7 @@
 
 {{ with site.Params.cms.publish_mode }}
   {{ $publish_mode := dict "publish_mode" . }}
-  {{ $backend_opts = merge $backend_opts $publish_mode }}
+  {{ $return = merge $return $publish_mode }}
 {{ end }}
 
 {{ if site.Params.cms.local_backend }}


### PR DESCRIPTION
### Purpose
**[BUGFIX]** Editorial workflow mode for CMS is not enabled after adding 'publish_mode: editorial_workflow' in params.yaml.

This is because _publish_mode_ entry (which should be a top level entry) is added under _backend_ entry in config.yaml.