### PR TITLE
Add data option for customizing loading address of highlight.js language styles.

### DIFF
--- a/wowchemy/data/assets.toml
+++ b/wowchemy/data/assets.toml
@@ -73,6 +73,11 @@
   sri = "sha512-gttPT9uTUiaLBj6XZdcB0ydKXiDaBwstInkN4Qvp1Nz3iwXNc8TTQplIEPIGxyJBDqERjwkKxf2OyO47/0EHbQ=="
   url = "https://cdnjs.cloudflare.com/ajax/libs/plotly.js/%s/plotly.min.js"
 
+[js.highlight_lang]
+  version = "10.2.0"
+  sri = ""  # No SRI as highlight language styles is determined at run time.
+  url = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/languages/%s.min.js"
+
 # CSS
 
 [css.fontAwesome]

--- a/wowchemy/layouts/partials/site_js.html
+++ b/wowchemy/layouts/partials/site_js.html
@@ -26,8 +26,9 @@
       {{ if $.Scratch.Get "highlight_enabled" }}
         {{ $v := $js.highlight.version }}
         {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.highlight.url $v) $js.highlight.sri | safeHTML }}
+        {{ $v := $js.highlight_lang.version }}
         {{ range site.Params.highlight_languages }}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
+        {{ printf "<script src=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.highlight_lang.url $v .) | safeHTML }}
         {{ end }}
       {{ end }}
 


### PR DESCRIPTION
### Purpose
Previously it was fixed to load styles from cdnjs, now it allows custom loading address.

In fact, jsDelivr is the only one available public global CDN in Mainland China.

https://www.jsdelivr.com/network#china