### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/wowchemy/layouts/partials/marketing/cloudflare.html
+++ b/wowchemy/layouts/partials/marketing/cloudflare.html
@@ -1,0 +1,3 @@
+{{ if hugo.IsProduction | and site.Params.marketing.cloudflare }}
+  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "{{site.Params.marketing.cloudflare}}"}'></script>
+{{ end }}

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -208,6 +208,7 @@
   {{ partial "marketing/google_tag_manager" . }}
   {{ partial "marketing/microsoft_clarity" . }}
   {{ partial "marketing/baidu_tongji" . }}
+  {{ partial "marketing/cloudflare" . }}
 
   {{/* Netlify Identity integration. */}}
   {{ $use_cms := templates.Exists "wowchemycms/single.wowchemycms_config.yml" | default (site.Params.cms.netlify_cms | default false) }}


### PR DESCRIPTION
### Purpose

This PR adds the possibility of using [Cloudflare Web Analytics](https://www.cloudflare.com/en-gb/web-analytics), a privacy-first, lightweight, accurate and free solution by Cloudflare, by adding your token under the `marketing` section in your `params.yaml` file:
```
marketing:
  cloudflare: ""
```

### Documentation

The new option should be added [here](https://wowchemy.com/docs/guide/analytics/).