### PR TITLE
Fix figure zooming out in some cases

### DIFF
--- a/wowchemy/assets/js/_vendor/medium-zoom.esm.js
+++ b/wowchemy/assets/js/_vendor/medium-zoom.esm.js
@@ -327,7 +327,7 @@ var mediumZoomEsm = function mediumZoom(selector) {
 
       var scaleX = Math.min(naturalWidth, viewportWidth) / width;
       var scaleY = Math.min(naturalHeight, viewportHeight) / height;
-      var scale = Math.min(scaleX, scaleY);
+      var scale = Math.max(1, Math.min(scaleX, scaleY));
       var translateX = (-left + (viewportWidth - width) / 2 + zoomOptions.margin + container.left) / scale;
       var translateY = (-top + (viewportHeight - height) / 2 + zoomOptions.margin + container.top) / scale;
       var transform = 'scale(' + scale + ') translate3d(' + translateX + 'px, ' + translateY + 'px, 0)';


### PR DESCRIPTION
In some cases, pressing a figure image makes it zoom out. This pull requests sets the minimal scale of the zoom to 1.

Gif of the issue:
![ezgif-4-8ed303087239](https://user-images.githubusercontent.com/31186542/125167307-8827d800-e1a8-11eb-9fa7-ac890ac7a118.gif)