### PR TITLE
feat: add shortcode to render a CSV as a table

### DIFF
--- a/wowchemy/layouts/shortcodes/table.html
+++ b/wowchemy/layouts/shortcodes/table.html
@@ -4,7 +4,7 @@
 
 {{ $src := .Get "src" }}
 {{ $delimiter := .Get "delimiter" | default "," }}
-{{ $useHeaderRow := .Get "header" }}
+{{ $useHeaderRow := .Get "header" | default true }}
 {{ $caption := .Get "caption" }}
 
 {{ $is_remote := strings.HasPrefix $src "http" }}

--- a/wowchemy/layouts/shortcodes/table.html
+++ b/wowchemy/layouts/shortcodes/table.html
@@ -1,0 +1,36 @@
+{{/* Table Shortcode for Wowchemy. */}}
+{{/* Load table from page dir falling back back to remote URL */}}
+{{/* Supports delimiter separated files. The default delimiter is ',' */}}
+
+{{ $src := .Get "src" }}
+{{ $delimiter := .Get "delimiter" | default "," }}
+{{ $useHeaderRow := .Get "header" }}
+{{ $caption := .Get "caption" }}
+
+{{ $is_remote := strings.HasPrefix $src "http" }}
+{{ if not $is_remote }}
+  {{ $src = path.Join  "content" $.Page.File.Dir $src }}
+{{ end }}
+{{ $rows := getCSV $delimiter $src }}
+
+<table>
+  {{ if $useHeaderRow }}
+    {{ $headerRow := index $rows 0 }}
+    {{ $rows = after 1 $rows }}
+    <tr> {{ range $headerRow }} <th>{{ . | markdownify | emojify }}</th> {{ end }} </tr>
+  {{ end }}
+  {{ range $rows }}
+    <tr>
+      {{ range . }}
+        {{ if (findRE "^\\d+$" .) }}
+          <td class="numeric">{{ . }}</td>
+        {{ else }}
+          <td>{{ . | markdownify | emojify }}</td>
+        {{ end }}
+      {{ end }}
+    </tr>
+  {{ end }}
+  {{ if $caption }}
+    <caption>{{ $caption | markdownify | emojify }}</caption>
+  {{ end }}
+</table>

--- a/wowchemy/layouts/shortcodes/table.html
+++ b/wowchemy/layouts/shortcodes/table.html
@@ -23,9 +23,9 @@
     <tr>
       {{ range . }}
         {{ if (findRE "^\\d+$" .) }}
-          <td class="numeric">{{ . }}</td>
+          <td data-table-dtype="number">{{ . }}</td>
         {{ else }}
-          <td>{{ . | markdownify | emojify }}</td>
+          <td data-table-dtype="text">{{ . | markdownify | emojify }}</td>
         {{ end }}
       {{ end }}
     </tr>


### PR DESCRIPTION
### Purpose

Resolves #2392 

Add support for

- [x] CSV file in page dir
- [x] CSV file in remote URL
- [x] Supports any delimiter


### Screenshots

If this is a GUI change, try to include screenshots of the change. If not, please delete this section.

### Documentation

```html
{{< table src="cars.csv" header=true caption="Table 1"  delimiter=";" >}}
```
| Tag | Default| Alternative|
|--|--|-|
|src| Name of a file in the page dir|A direct remote URL to csv|
|header|true| false won't let the row 0 to be header|
|delimiter|,| ;,/,\t etc.|