### PR TITLE
Improved Netlify Forms

### DIFF
--- a/wowchemy/i18n/ca.yaml
+++ b/wowchemy/i18n/ca.yaml
@@ -75,13 +75,15 @@
 - id: more_publications
   translation: Més publicacions
 - id: contact_name
-  translation: Name
+  translation: Nom
 - id: contact_email
   translation: Email
 - id: contact_message
-  translation: Message
+  translation: Missatge
+- id: contact_attachment
+  translation: Adjunt  
 - id: contact_send
-  translation: Send
+  translation: Enviar
 - id: book_appointment
   translation: Book an appointment
 - id: abstract

--- a/wowchemy/i18n/en.yaml
+++ b/wowchemy/i18n/en.yaml
@@ -138,6 +138,9 @@
 
 - id: contact_message
   translation: Message
+  
+- id: contact_attachment
+  translation: Attachment  
 
 - id: contact_send
   translation: Send

--- a/wowchemy/i18n/en.yaml
+++ b/wowchemy/i18n/en.yaml
@@ -140,7 +140,7 @@
   translation: Message
   
 - id: contact_attachment
-  translation: Attachment  
+  translation: Attach file
 
 - id: contact_send
   translation: Send

--- a/wowchemy/i18n/es.yaml
+++ b/wowchemy/i18n/es.yaml
@@ -80,6 +80,8 @@
   translation: Email
 - id: contact_message
   translation: Mensaje
+- id: contact_attachment
+  translation: Adjunto  
 - id: contact_send
   translation: Enviar
 - id: book_appointment

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -38,7 +38,7 @@
     {{ end }}
 
     <div class="mb-3">
-      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }} {{ with $st.Params.content.form.netlify.success_url }}action="{{ . | relLangUrl }}"{{ end }}>
+      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }} {{ with $st.Params.content.form.netlify.success_url }}action="{{ . | relLangURL }}"{{ end }}>
         <div class="form-group form-inline">
           <label class="sr-only" for="inputName">{{ i18n "contact_name" }}</label>
           <input type="text" name="name" class="form-control w-100" id="inputName" placeholder="{{ i18n "contact_name" | default "Name" }}" required>

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -38,7 +38,7 @@
     {{ end }}
 
     <div class="mb-3">
-      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }} {{ if $st.Params.content.form.netlify.success_page }} action="{{ $st.Params.content.form.netlify.success_page }}" {{ end }}>
+      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }} {{ with $st.Params.content.form.netlify.success_url }}action="{{ . | relLangUrl }}"{{ end }}>
         <div class="form-group form-inline">
           <label class="sr-only" for="inputName">{{ i18n "contact_name" }}</label>
           <input type="text" name="name" class="form-control w-100" id="inputName" placeholder="{{ i18n "contact_name" | default "Name" }}" required>
@@ -54,7 +54,7 @@
         {{ if $st.Params.content.form.netlify.attachments }}
           <div class="form-group form-inline">
             <label class="sr-only" for="fileUpload">{{ i18n "contact_attachment" }}</label>
-            <input type="file" name="file" class="form-control w-100" id="fileUpload" placeholder="{{ i18n "contact_attachment" | default "Attachment" }}">
+            <input type="file" name="file" class="form-control w-100" id="fileUpload" placeholder="{{ i18n "contact_attachment" | default "Attach file" }}">
           </div>
         {{ end }}
         <div class="d-none">

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -51,6 +51,12 @@
           <label class="sr-only" for="inputMessage">{{ i18n "contact_message" }}</label>
           <textarea name="message" class="form-control" id="inputMessage" rows="5" placeholder="{{ i18n "contact_message" | default "Message" }}" required></textarea>
         </div>
+        {{ if $st.Params.content.form.netlify.file_uploads }}
+          <div class="form-group form-inline">
+            <label class="sr-only" for="fileUpload">{{ i18n "contact_attachment" }}</label>
+            <input type="file" name="file" class="form-control w-100" id="fileUpload" placeholder="{{ i18n "contact_attachment" | default "Attachment" }}">
+          </div>
+        {{ end }}
         <div class="d-none">
           <label>Do not fill this field unless you are a bot: <input name="_gotcha"></label>
         </div>

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -51,7 +51,7 @@
           <label class="sr-only" for="inputMessage">{{ i18n "contact_message" }}</label>
           <textarea name="message" class="form-control" id="inputMessage" rows="5" placeholder="{{ i18n "contact_message" | default "Message" }}" required></textarea>
         </div>
-        {{ if $st.Params.content.form.netlify.file_uploads }}
+        {{ if $st.Params.content.form.netlify.attachments }}
           <div class="form-group form-inline">
             <label class="sr-only" for="fileUpload">{{ i18n "contact_attachment" }}</label>
             <input type="file" name="file" class="form-control w-100" id="fileUpload" placeholder="{{ i18n "contact_attachment" | default "Attachment" }}">

--- a/wowchemy/layouts/partials/widgets/contact.html
+++ b/wowchemy/layouts/partials/widgets/contact.html
@@ -38,7 +38,7 @@
     {{ end }}
 
     <div class="mb-3">
-      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }}>
+      <form name="contact" method="POST" {{ $post_action | safeHTMLAttr }} {{ if $use_netlify_form }}netlify-honeypot="_gotcha"{{ end }} {{ if $use_netlify_captcha }}data-netlify-recaptcha="true"{{ end }} {{ if $st.Params.content.form.netlify.success_page }} action="{{ $st.Params.content.form.netlify.success_page }}" {{ end }}>
         <div class="form-group form-inline">
           <label class="sr-only" for="inputName">{{ i18n "contact_name" }}</label>
           <input type="text" name="name" class="form-control w-100" id="inputName" placeholder="{{ i18n "contact_name" | default "Name" }}" required>


### PR DESCRIPTION
### Purpose

[Encouraged by @gcushen](https://github.com/wowchemy/wowchemy-hugo-modules/pull/2377#issuecomment-884489208), this PR adds the possibility of adding an optional custom success page, as documented [here](https://docs.netlify.com/forms/setup/#success-messages), and optional file uploads, as documented [here](https://docs.netlify.com/forms/setup/#file-uploads), to Netlify forms, by adding this to the `contact` widget:

```
form:
  provider: netlify    
  netlify:
    captcha: true
    success_page: /thank-you
    file_uploads: true
```

### Screenshots

#### Example _Thank you_ page (live version [here](https://physichemically.com/thank-you/))
An example of a _Thank you_ page could be this, showing a Wowchemy-styled _Go back_ button:

```
---
title: "THANK YOU!"
reading_time: false  # Show estimated reading time?
share: false  # Show social sharing links?
profile: false  # Show author profile?
commentable: false  # Allow visitors to comment?
editable: false  # Allow visitors to edit the page?
---

The form has been sent successfully.

<a onclick="window.history.back()" class="btn btn-primary px-3 py-3">Go back</a>
```
![image](https://user-images.githubusercontent.com/9049533/126600525-04abcadb-7c3d-4845-be40-26ff5a04c477.png)

#### Contact form showing and optional field for file uploads (live version [here](https://physichemically.com/#contact))
![image](https://user-images.githubusercontent.com/9049533/126600847-7e4200d1-eb1f-4d1e-a091-e4ae2be20cb1.png)


### Documentation

These new options should be documented [here](https://wowchemy.com/docs/widget/contact/#contact-form).
