### PR TITLE
Remove unwanted spaces in custom page links

### DIFF
--- a/wowchemy/layouts/partials/page_links.html
+++ b/wowchemy/layouts/partials/page_links.html
@@ -153,6 +153,6 @@
   {{ end }}
   <a class="btn btn-outline-primary btn-page-header{{ if $is_list }} btn-sm{{end}}" href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
     {{ if .icon }}<i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }} {{if .name}}mr-1{{end}}"></i>{{end}}
-    {{ with .name }}{{ . | safeHTML }}{{end}}
+    {{- with .name }}{{ . | safeHTML }}{{ end -}}
   </a>
 {{ end }}


### PR DESCRIPTION
This PR removes unwanted spaces in custom links, before and after the `name` (the icon already has the `mr-1` class).

## Before
```
<a class="btn btn-outline-primary btn-page-header" href="/recursos-fisica-quimica/apuntes/2bach/quimica/redox/redox-ejercicios.pdf">
    <i class="fas fa-pencil-ruler mr-1"></i>
    " Ejercicios "
</a>
```

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/9049533/128981679-abdc4b9d-5612-4068-a57a-ea3da36e5f23.png">

## After
```
<a class="btn btn-outline-primary btn-page-header" href="/recursos-fisica-quimica/apuntes/2bach/quimica/redox/redox-ejercicios.pdf">
    <i class="fas fa-pencil-ruler mr-1"></i>
    "Ejercicios"
</a>
```

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/9049533/128981805-06a379a3-2687-4192-aa65-88a9260989a8.png">
