### PR TITLE
Adding support for a vertical timeline list

### DIFF
--- a/wowchemy/assets/scss/wowchemy/components/_all.scss
+++ b/wowchemy/assets/scss/wowchemy/components/_all.scss
@@ -8,3 +8,4 @@
 @import 'pagination';
 @import 'sharing';
 @import 'shortcode';
+@import 'timeline';

--- a/wowchemy/assets/scss/wowchemy/components/_timeline.scss
+++ b/wowchemy/assets/scss/wowchemy/components/_timeline.scss
@@ -1,0 +1,161 @@
+// Vertical Timeline
+
+.timeline {
+  position: relative;
+  margin: 50px auto;
+  padding: 40px 0;
+  box-sizing: border-box;
+
+  &:before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    width: 3px;
+    height: 100%;
+    background: #c5c5c5;
+  }
+
+  ul {
+    padding: 0;
+    margin: 0;
+
+    li {
+      list-style: none;
+      position: relative;
+      width: 50%;
+      padding: 20px 40px;
+      box-sizing: border-box;
+
+      &:nth-child(odd) {
+        float: left;
+        text-align: right;
+        clear: both;
+
+        &:before {
+          content: '';
+          position: absolute;
+          width: 10px;
+          height: 10px;
+          top: 24px;
+          right: -6px;
+          background: #fff;
+          border-radius: 50%;
+          box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.2);
+        }
+
+        .time {
+          font-size: 14px;
+          position: absolute;
+          top: 12px;
+          right: -150px;
+          margin: 0;
+          padding: 0;
+          padding: 8px 16px;
+          color: #fff;
+          border-radius: 18px;
+        }
+      }
+
+      &:nth-child(even) {
+        float: right;
+        text-align: left;
+        clear: both;
+
+        &:before {
+          content: '';
+          position: absolute;
+          width: 10px;
+          height: 10px;
+          top: 24px;
+          left: -4px;
+          background: #fff;
+          border-radius: 50%;
+          box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.2);
+        }
+
+        .time {
+          font-size: 14px;
+          position: absolute;
+          top: 12px;
+          left: -150px;
+          margin: 0;
+          padding: 0;
+          padding: 8px 16px;
+          color: #fff;
+          border-radius: 18px;
+        }
+      }
+
+      h3 {
+        padding: 0;
+        margin: 0;
+      }
+
+      p {
+        margin: 10px 0 0;
+        padding: 0;
+      }
+    }
+  }
+}
+
+.content {
+  padding-bottom: 20px;
+}
+
+@media {
+  .timeline {
+    width: 100%;
+    padding-bottom: 0;
+
+    &:before {
+      left: 20px;
+      height: 100%;
+    }
+
+    ul {
+      li {
+        &:nth-child(odd) {
+          width: 100%;
+          text-align: left;
+          padding-left: 50px;
+          padding-bottom: 50px;
+
+          &:before {
+            top: -18px;
+            left: 16px;
+          }
+
+          .time {
+            top: -30px;
+            left: 50px;
+            right: inherit;
+          }
+        }
+
+        &:nth-child(even) {
+          width: 100%;
+          text-align: left;
+          padding-left: 50px;
+          padding-bottom: 50px;
+
+          &:before {
+            top: -18px;
+            left: 16px;
+          }
+
+          .time {
+            top: -30px;
+            left: 50px;
+            right: inherit;
+          }
+        }
+      }
+    }
+  }
+
+  h1 {
+    font-size: 40px;
+    text-align: center;
+  }
+}

--- a/wowchemy/layouts/_default/list.html
+++ b/wowchemy/layouts/_default/list.html
@@ -7,17 +7,21 @@
     <div class="article-style">{{ . }}</div>
   {{ end }}
 
+  {{ if eq $.Params.view 5 }}
+  <div class="timeline">
+    <ul>
+  {{ end }}
+
   {{ $paginator := .Paginate .Pages }}
   {{ range $paginator.Pages }}
-    {{ if eq $.Params.view 1 }}
-      {{ partial "li_list" . }}
-    {{ else if eq $.Params.view 3 }}
-      {{ partial "li_card" . }}
-    {{ else if eq $.Params.view 4 }}
-      {{ partial "li_citation" . }}
-    {{ else }}
-      {{ partial "li_compact" . }}
-    {{ end }}
+    {{ $view := partial "functions/get_view_by_number" ($.Params.view | default 2) }}
+    {{ partial $view . }}
+  {{ end }}
+
+  {{ if eq $.Params.view 5 }}
+      <div style="clear:both;"></div>
+    </ul>
+  </div>
   {{ end }}
 
   {{ partial "pagination" . }}

--- a/wowchemy/layouts/partials/functions/get_summary.html
+++ b/wowchemy/layouts/partials/functions/get_summary.html
@@ -1,0 +1,14 @@
+{{/* Return the found summary if any. Defaults to empty string */}}
+
+{{ $item := . }}
+{{ $summary := "" }}
+
+{{ if $item.Params.summary }}
+  {{ $summary = $item.Params.summary | markdownify | emojify }}
+{{ else if .Params.abstract }}
+  {{ $summary = .Params.abstract | markdownify | emojify }}
+{{ else if $item.Summary }}
+  {{ $summary = $item.Summary }}
+{{ end }}
+
+{{ return $summary }}

--- a/wowchemy/layouts/partials/functions/get_view_by_number.html
+++ b/wowchemy/layouts/partials/functions/get_view_by_number.html
@@ -1,0 +1,18 @@
+{{/* Return the right view partial based on the index number */}}
+
+{{/* Defaults to compact view. */}}
+{{ $view := "li_compact" }}
+
+{{ $view_number := (int .) }}
+
+{{ if eq $view_number 1 }}
+  {{ $view = "li_list" }}
+{{ else if eq $view_number 3 }}
+  {{ $view = "li_card" }}
+{{ else if eq $view_number 4 }}
+  {{ $view = "li_citation" }}
+{{- else if eq $view_number 5 -}}
+  {{ $view = "li_timeline" }}
+{{ end }}
+
+{{ return $view }}

--- a/wowchemy/layouts/partials/li_card.html
+++ b/wowchemy/layouts/partials/li_card.html
@@ -4,14 +4,7 @@
 {{ $has_attachments := partial "functions/has_attachments" . }}
 
 {{/* Get summary. */}}
-{{ $summary := "" }}
-{{ if $item.Params.summary }}
-  {{ $summary = $item.Params.summary | markdownify | emojify }}
-{{ else if .Params.abstract }}
-  {{ $summary = .Params.abstract | markdownify | emojify }}
-{{ else if $item.Summary }}
-  {{ $summary = $item.Summary }}
-{{ end }}
+{{ $summary := partial "functions/get_summary" $item }}
 
 <div class="card-simple">
 

--- a/wowchemy/layouts/partials/li_timeline.html
+++ b/wowchemy/layouts/partials/li_timeline.html
@@ -1,0 +1,53 @@
+{{ $item := . }}
+
+{{/* Dynamic view adjusts to content type. */}}
+{{ $has_attachments := partial "functions/has_attachments" . }}
+
+{{ $link := $item.RelPermalink }}
+
+{{ if $item.Params.external_link }}
+  {{ $link = $item.Params.external_link }}
+{{ end }}
+
+{{/* Get summary. */}}
+{{ $summary := partial "functions/get_summary" $item }}
+
+{{/* Get page creation datetime and format into human-readable date */}}
+{{ $datetime := $item.PublishDate }}
+
+<li>
+  <div class="content">
+    <a href="{{ $link }}"><h3>{{ $item.Title }}</h3></a>
+
+    {{ with $summary }}
+    <a href="{{ $link }}" class="summary-link">
+      <div class="article-style">
+        <p>{{.}}</p>
+      </div>
+    </a>
+    {{ end }}
+
+    {{ $resource := ($item.Resources.ByType "image").GetMatch "*featured*" }}
+    {{ $anchor := $item.Params.image.focal_point | default "Smart" }}
+    {{ with $resource }}
+    {{ $image := .Fill (printf "808x455 %s" $anchor) }}
+    <a href="{{ $link }}">
+      <div class="img-hover-zoom">
+        <img src="{{ $image.RelPermalink }}" class="article-banner" alt="{{ $item.Title }}" loading="lazy">
+      </div>
+    </a>
+    {{end}}
+
+    {{ if $has_attachments }}
+    <div class="btn-links">
+      {{ partial "page_links" (dict "page" $item "is_list" 1) }}
+    </div>
+    {{ end }}
+  </div>
+
+  <a href="{{ $link }}">
+    <time class="time btn btn-primary btn-lg" datetime="{{ $datetime.Format "2006-01-02T15:04:05Z0700" }}">
+      {{ $datetime.Format "January 2006" }}
+    </time>
+  </a>
+</li>

--- a/wowchemy/layouts/section/publication.html
+++ b/wowchemy/layouts/section/publication.html
@@ -57,15 +57,8 @@
         {{ end }}
 
         <div class="grid-sizer col-lg-12 isotope-item pubtype-{{ $.Scratch.Get "pubtype" }} year-{{ .Date.Format "2006" }}">
-          {{ if eq $.Params.view 1 }}
-            {{ partial "li_list" . }}
-          {{ else if eq $.Params.view 3 }}
-            {{ partial "li_card" . }}
-          {{ else if eq $.Params.view 4 }}
-            {{ partial "li_citation" . }}
-          {{ else }}
-            {{ partial "li_compact" . }}
-          {{ end }}
+          {{ $view := partial "functions/get_view_by_number" ($.Params.view | default 2) }}
+          {{ partial $view . }}
         </div>
 
         {{ end }}

--- a/wowchemy/layouts/shortcodes/cite.html
+++ b/wowchemy/layouts/shortcodes/cite.html
@@ -1,17 +1,5 @@
 {{ $page := .Get "page" }}
 
-{{/* Default compact view. */}}
-{{ $view := (.Get "view") | default 2 }}
-{{ $view = int $view }}
-
 {{ with site.GetPage $page }}
-  {{ if eq $view 1 }}
-    {{ partial "li_list" . }}
-  {{ else if eq $view 3 }}
-    {{ partial "li_card" . }}
-  {{ else if eq $view 4 }}
-    {{ partial "li_citation" . }}
-  {{ else }}
-    {{ partial "li_compact" . }}
-  {{ end }}
+  {{ partial (partial "functions/get_view_by_number" (int (.Get "view") | default 2)) }}
 {{ end }}


### PR DESCRIPTION
:information_source: Note: this feature is not complete yet, so I'm opening the PR as a draft.

The implementation was inspired by Sanchit Sharma's Code Pen [[ref]](https://codepen.io/web_designer_sanchit/pen/eLjvyw).
Kudos to [the author](https://codepen.io/web_designer_sanchit/) :rocket:

I can find my way around Go templates and HTML, however, my CSS knowledge is
very limited. I would love to have some feedback on how to make better reusability of
style definitions, especially in regards to the dark/light theme colors
(note that the timeline circle is currently hard-coded as white and doesn't display when
the background is white).

### Purpose

This change introduces a vertical timeline (example [available here](https://macunha.me/en/project/)),
the goal was to display (mostly) projects in a way that we could put them into
a time perspective and sequence the "evolution" of knowledge, or of our career for
instance. The same implementation could be used to represent working experience,
events and etc.

During research I found some resources that served as inspiration:
 + Ref: https://github.com/stephane-monnot/react-vertical-timeline;
 + Ref: https://github.com/CodyHouse/vertical-timeline;

### Caveats

- Since the color for the timeline circle is hard-coded (to white) in the SCSS file,
  day and light themes aren't currently working as they should (only night);

- On very small smartphone screens the text will look weird. I would appreciate
  some tips on how to redistribute it to one side only [like this Code Pen](https://codepen.io/savalazic/pen/QKwERN);

### Screenshots

#### Light

![Screenshot_2021-08-13_07-48-46](https://user-images.githubusercontent.com/12192633/129310972-fd998422-27c6-4c9e-be2f-f3e626ffaad2.png)

#### Dark

![Screenshot_2021-08-13_07-49-06](https://user-images.githubusercontent.com/12192633/129311028-d94f8308-7909-46a7-afda-4e3dd3ae9ba4.png)

### Documentation

> :information_source: I intend to document these changes as the last step, after having the code commentaries
> updated. Since it will introduce `view = 5` so that users know how to use it.

For the sake of completeness, this is what I have in my `content/en/project/_index.md`
file (as of this writing):

```yaml
---
title: Projects

# View.
#   1 = List
#   2 = Compact
#   3 = Card
#   5 = Timeline
view: 5
---
```