### PR TITLE
Update Academicons font library to v1.9.1

### DIFF
--- a/wowchemy/data/assets.toml
+++ b/wowchemy/data/assets.toml
@@ -72,8 +72,8 @@
 # CSS
 
 [css.academicons]
-  version = "1.9.0"
-  sri = "sha512-W4yqoT1+8NLkinBLBZko+dFB2ZbHsYLDdr50VElllRcNt2Q4/GSs6u71UHKxB7S6JEMCp5Ve4xjh3eGQl/HRvg=="
+  version = "1.9.1"
+  sri = "sha512-b1ASx0WHgVFL5ZQhTgiPWX+68KjS38Jk87jg7pe+qC7q9YkEtFq0z7xCglv7qGIs/68d3mAp+StfC8WKC5SSAg=="
   url = "https://cdnjs.cloudflare.com/ajax/libs/academicons/%s/css/academicons.min.css"
 [css.leaflet]
   version = "1.7.1"


### PR DESCRIPTION
### Purpose

This PR updates the Academicons font library to the latest version (v1.9.1). This fixes issue #2465. Even though that issue is already closed, the latest version contains some stylistic consistency fixes.
