### PR TITLE
feat: allow figcaptions outside figures

### DIFF
--- a/wowchemy/assets/scss/wowchemy/elements/_media.scss
+++ b/wowchemy/assets/scss/wowchemy/elements/_media.scss
@@ -49,24 +49,24 @@ figure {
     height: auto;
     max-width: 100%;
   }
+}
 
-  figcaption {
-    margin-top: 0.75em;
-    margin-bottom: 1.65rem;
-    line-height: 1.4;
-    font-size: 0.76rem;
-    text-align: center; // Center figure captions.
-  }
+figcaption {
+  margin-top: 0.75em;
+  margin-bottom: 1.65rem;
+  line-height: 1.4;
+  font-size: 0.76rem;
+  text-align: center; // Center figure captions.
+}
 
-  figcaption.numbered::before {
-    font-weight: 700;
-    text-transform: uppercase;
-    content: attr(data-pre) counter(captions) attr(data-post);
-  }
+figcaption.numbered::before {
+  font-weight: 700;
+  text-transform: uppercase;
+  content: attr(data-pre) counter(captions) attr(data-post);
+}
 
-  figcaption.numbered {
-    counter-increment: captions;
-  }
+figcaption.numbered {
+  counter-increment: captions;
 }
 
 /*************************************************


### PR DESCRIPTION
### Purpose

This broadens the scope of figcaptions such that they can be used outside figures.

This is handy for manually adding captions to equations:

```md
$
a = b
$
<figcaption>Equation 1: $a$ is the same as $b$</figcaption>
```

### Screenshots

After:
![image](https://user-images.githubusercontent.com/1814611/170062534-bf049ca1-177a-4e60-b3e0-8df9d4e3c3bd.png)

Before:
![image](https://user-images.githubusercontent.com/1814611/170062635-e1a91297-a934-42c2-972d-7e01a3d84f45.png)


### Documentation

I would be happy to add a section to the documentation if deemed relevant.
