### PR TITLE
Update get_hook.html

### DIFF
--- a/modules/blox-core/layouts/_partials/blox-core/functions/get_hook.html
+++ b/modules/blox-core/layouts/_partials/blox-core/functions/get_hook.html
@@ -5,7 +5,7 @@
 {{ $loaded := false }}
 {{ $partial_dir := printf "hooks/%s/" .hook }}
 {{ $context := .context }}
-{{ $hook_dir_path := path.Join "layouts/partials" $partial_dir }}
+{{ $hook_dir_path := path.Join "layouts/_partials" $partial_dir }}
 {{ if fileExists $hook_dir_path }}
   {{ range os.ReadDir $hook_dir_path }}
     {{ if not .IsDir }}


### PR DESCRIPTION
Fix for hooks not working after the update to the new Hugo template system.
