### PR TITLE
fix: regression with custom icon rendering

### DIFF
--- a/modules/blox-tailwind/layouts/_partials/functions/get_icon.html
+++ b/modules/blox-tailwind/layouts/_partials/functions/get_icon.html
@@ -43,9 +43,9 @@
           )
       }}
     {{- end -}}
-    {{- $icon := resources.Get $icon_path -}}
-    {{ if $icon }}
-      {{ $icon = .Content }}
+    {{- $icon_resource := resources.Get $icon_path -}}
+    {{ if $icon_resource }}
+      {{ $icon = $icon_resource.Content }}
     {{ else }}
       {{ $icon = index (index site.Data.icons.brands "icons") "hugo" }}
     {{ end }}


### PR DESCRIPTION
### Purpose

Fixes #3278. Icons are not rendered properly due to the variable `$icon` shadowing the outer scope variable of the same name.