### PR TITLE
Potential fix for code scanning alert no. 10: Double escaping or unescaping

### DIFF
--- a/modules/blox-tailwind/blox/shared/js/components/Icon.jsx
+++ b/modules/blox-tailwind/blox/shared/js/components/Icon.jsx
@@ -14,9 +14,9 @@ export const Icon = ({svg, attributes}) => {
     .replace(/\\u0026/gi, "&")
     .replace(/&lt;/gi, "<")
     .replace(/&gt;/gi, ">")
-    .replace(/&amp;/gi, "&")
     .replace(/&quot;/gi, '"')
-    .replace(/&#34;/gi, '"');
+    .replace(/&#34;/gi, '"')
+    .replace(/&amp;/gi, "&");
 
   const hasWrapper = /<svg[\s>]/i.test(decoded);
 


### PR DESCRIPTION
Potential fix for [https://github.com/HugoBlox/hugo-blox-builder/security/code-scanning/10](https://github.com/HugoBlox/hugo-blox-builder/security/code-scanning/10)

To fix the double unescaping error, the ampersand replacement (`.replace(/&amp;/gi, "&")`) must occur *after* all other HTML entity replacements that depend on `&` (e.g., `&lt;`, `&gt;`, `&quot;`, `&#34;`). This means you should move the `.replace(/&amp;/gi, "&")` call after the calls to handle `&lt;`, `&gt;`, `&quot;`, and `&#34;`. This reordering ensures that a sequence like `&amp;quot;` will first be decoded to `&quot;`, which can then safely be decoded to `"`. Only the block of code from lines 11-19 needs updating. No new imports or extra utilities are required; only the order of replacement calls in the decoding sequence must change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
