### PR TITLE
fix: CSS class for hb-card-title to remove redundant items-start

### DIFF
--- a/modules/blox-tailwind/assets/css/components/cards.css
+++ b/modules/blox-tailwind/assets/css/components/cards.css
@@ -23,7 +23,7 @@
 }
 
 .hb-card-title {
-  @apply flex font-semibold items-start gap-2 text-gray-700 hover:text-gray-900 items-center;
+  @apply flex font-semibold gap-2 text-gray-700 hover:text-gray-900 items-center;
 
   color: var(--color-neutral-700);
 }


### PR DESCRIPTION
### 🚀 What type of change is this?

- [ ] 🐛 **Bug fix** (A non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (A non-breaking change that adds functionality)
- [x] 💅 **Style change** (A change that only affects formatting, visuals, or styling)
- [ ] 📚 **Documentation update** (Changes to documentation only)
- [ ] 🧹 **Refactor or chore** (A code change that neither fixes a bug nor adds a feature)
- [ ] 💥 **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)

---

### 🎯 What is the purpose of this change?

Suggests keeping only items-center to ensure that icons align to the same line as text in a card.

---

### 📸 Screenshots or Screencast (if applicable)

🐱

---

### ℹ️ Documentation Check

- [x] No, this change does not require a documentation update.
- [ ] Yes, I have updated the documentation accordingly (or will in a follow-up PR).

---

### 📜 Contributor Agreement

**Thank you for your contribution!**

- [x] By checking this box, I confirm that I have read and agree to the [HugoBlox Contributor License Agreement (CLA)](/.github/CLA.md).
