### PR TITLE
fix(sitemap): ensure sitemap excludes pages with frontmatter sitemap …

### DIFF
--- a/modules/blox/layouts/sitemap.xml
+++ b/modules/blox/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{/* Check that page is built (has a URL) and is not private. */}}
-  {{ range where (where .Data.Pages "Permalink" "!=" "") "Params.private" "ne" true }}
+  {{ range where (where (where .Data.Pages "Permalink" "!=" "") "Params.private" "ne" true) ".Sitemap.Disable" "ne" true }}  
   <url>
     <loc>{{ .Permalink }}</loc>
     {{- if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}


### PR DESCRIPTION
### 🚀 What type of change is this?

- [ x] 🐛 **Bug fix** (A non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (A non-breaking change that adds functionality)
- [ ] 💅 **Style change** (A change that only affects formatting, visuals, or styling)
- [ ] 📚 **Documentation update** (Changes to documentation only)
- [ ] 🧹 **Refactor or chore** (A code change that neither fixes a bug nor adds a feature)
- [ ] 💥 **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)

---

### 🎯 What is the purpose of this change?
The sitemap currently includes pages that are explicitly disabled via frontmatter (e.g. `sitemap.disable = true`).

This behavior is unexpected, as pages marked for exclusion from the sitemap should not appear in the generated `sitemap.xml`.

The purpose of this change is to update the Hugo Blox sitemap layout so that it correctly respects the `sitemap.disable` frontmatter flag and excludes those pages from the sitemap.

---

### 📸 Screenshots or Screencast (if applicable)
Not applicable.

Example frontmatter:

```yaml
sitemap:
  disable: true
```

---

### ℹ️ Documentation Check

- [ x] No, this change does not require a documentation update.
- [ ] Yes, I have updated the documentation accordingly (or will in a follow-up PR).

---

### 📜 Contributor Agreement

**Thank you for your contribution!**

- [x ] By checking this box, I confirm that I have read and agree to the [HugoBlox Contributor License Agreement (CLA)](/.github/CLA.md).
