### PR TITLE
fix(404): exclude sitemap-disabled pages from 404 suggestions

### DIFF
--- a/modules/blox/layouts/404.html
+++ b/modules/blox/layouts/404.html
@@ -8,7 +8,7 @@
 
     <p>{{ i18n "404_recommendations" }}</p>
 
-    {{ $query := where (where (where (where site.Pages.ByDate.Reverse "Title" "!=" "") "Kind" "in" (slice "page" "section")) "Params.private" "!=" true) "Permalink" "!=" "" }}
+    {{ $query := where (where (where (where (where site.Pages.ByDate.Reverse "Title" "!=" "") "Kind" "in" (slice "page" "section")) "Params.private" "!=" true) "Params.sitemap.disable" "!=" true) "Permalink" "!=" "" }}
     {{ $count := len $query }}
     {{ if gt $count 0 }}
     <h2>{{ i18n "user_profile_latest" }}</h2>


### PR DESCRIPTION
Previously, pages with sitemap.disable=true were shown in 404 suggestions. This change filters them out for consistency and better UX.

### 🚀 What type of change is this?

- [x] 🐛 **Bug fix** (A non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (A non-breaking change that adds functionality)
- [ ] 💅 **Style change** (A change that only affects formatting, visuals, or styling)
- [ ] 📚 **Documentation update** (Changes to documentation only)
- [ ] 🧹 **Refactor or chore** (A code change that neither fixes a bug nor adds a feature)
- [ ] 💥 **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)

---

### 🎯 What is the purpose of this change?

This change updates the 404 page layout to respect frontmatter flags, such as 1sitemap.disable1, ensuring that hidden or excluded pages do not appear in 404 suggestions. It improves consistency with the sitemap, prevents accidental exposure of private content, and provides a cleaner user experience.
---

### 📸 Screenshots or Screencast (if applicable)
Not applicable
---

### ℹ️ Documentation Check

- [ x] No, this change does not require a documentation update.
- [ ] Yes, I have updated the documentation accordingly (or will in a follow-up PR).

---

### 📜 Contributor Agreement

**Thank you for your contribution!**

- [ x] By checking this box, I confirm that I have read and agree to the [HugoBlox Contributor License Agreement (CLA)](/.github/CLA.md).
