### PR TITLE
fix(rss): RSS feed respects sitemap-disabled pages

### DIFF
--- a/modules/blox/layouts/rss.xml
+++ b/modules/blox/layouts/rss.xml
@@ -2,6 +2,7 @@
 {{- /* Upstream Hugo bug - RSS dates can be in future: https://github.com/gohugoio/hugo/issues/3918 */ -}}
 {{- $page_context := cond .IsHome site . -}}
 {{- $pages := $page_context.RegularPages -}}
+{{- $pages = where $pages "Params.sitemap.disable" "!=" true -}}
 {{- $limit := site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}
   {{- $pages = $pages | first $limit -}}
@@ -16,7 +17,7 @@
     {{ end -}}
     <description>{{ .Title | default site.Title }}</description>
     <generator>HugoBlox Kit (https://hugoblox.com)</generator>
-    {{- with site.Language.Locale }}<language>{{.}}</language>{{end -}}
+    {{- with site.LanguageCode }}<language>{{.}}</language>{{end -}}
     {{- with site.Copyright }}<copyright>{{ strings.ReplacePairs . "{year}" now.Year "&copy;" "©" | plainify }}</copyright>{{end -}}
     {{- if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end -}}
     {{- if .Scratch.Get "og_image" }}


### PR DESCRIPTION
### 🚀 What type of change is this?

- [x ] 🐛 **Bug fix** (A non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (A non-breaking change that adds functionality)
- [ ] 💅 **Style change** (A change that only affects formatting, visuals, or styling)
- [ ] 📚 **Documentation update** (Changes to documentation only)
- [ ] 🧹 **Refactor or chore** (A code change that neither fixes a bug nor adds a feature)
- [ ] 💥 **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)

---

### 🎯 What is the purpose of this change?
The default RSS feed in Hugo Blox Kit does not respect the frontmatter flag `sitemap.disable`. As a result, excluded pages can appear in the RSS feed, which is inconsistent with the sitemap and may unintentionally expose content.  

This change updates the RSS layout to **exclude sitemap-disabled pages**, ensuring the feed only contains indexable content.  

---

### 📸 Screenshots or Screencast (if applicable)
Not applicable
---

### ℹ️ Documentation Check

- [ x] No, this change does not require a documentation update.
- [ ] Yes, I have updated the documentation accordingly (or will in a follow-up PR).

---

### 📜 Contributor Agreement

**Thank you for your contribution!**

- [x ] By checking this box, I confirm that I have read and agree to the [HugoBlox Contributor License Agreement (CLA)](/.github/CLA.md).
